### PR TITLE
Fix Z84C30::In() returning a floating bus instead of the live counter

### DIFF
--- a/CPCCoreEmu/Z84C30.cpp
+++ b/CPCCoreEmu/Z84C30.cpp
@@ -226,4 +226,8 @@ void Z84C30::Out(unsigned short address, unsigned char data)
 
 void Z84C30::In(unsigned char* data, unsigned short address)
 {
+   // Real Z80 CTC always answers a channel read with the current
+   // down-counter value (live or latched), never a floating bus.
+   // down_counter_ is kept exactly current by Tick() on every call.
+   *data = channel_[address & 0x3].down_counter_;
 }

--- a/UnitTests/TestZ84C30.cpp
+++ b/UnitTests/TestZ84C30.cpp
@@ -108,3 +108,42 @@ TEST(Z84C30, count_to_interrupt)
    ASSERT_EQ(interrupt.IsInterruted(), true);
 
 }
+
+// TEST : In() must return the live down-counter value, not a floating bus.
+// Real Z80 CTC hardware never floats a channel read -- it always answers
+// with the current count. The original In() body was empty (never wrote
+// *data at all), so a caller reading a channel always saw whatever was in
+// its buffer before the call (a "floating bus" from the emulator's point of
+// view) instead of the real counter value.
+TEST(Z84C30, In_ReturnsLiveDownCounterValue)
+{
+   Z84C30 z84c30;
+   Interrupt interrupt;
+
+   z84c30.Init(Z84C30::CHANNEL_0, nullptr, &interrupt);
+   // EnableInterrupt, Timer, x16, Rising edge, Auto, time constant following
+   z84c30.Out(0, 0x85);
+   // Time constant : 16
+   z84c30.Out(0, 16);
+
+   // Tick to load the constant, then run a handful of counts down.
+   for (int i = 0; i < 1 + 16 * 5; i++)
+      z84c30.Tick();
+
+   // 5 full x16 prescaler cycles consumed -> down-counter should read 11.
+   unsigned char data = 0xFF;
+   z84c30.In(&data, 0);
+   EXPECT_EQ(data, 11);
+}
+
+// TEST : In() on a channel that was never armed (no time constant, no Trg)
+// must still return the counter's real state (0, its reset value) rather
+// than leaving the caller's buffer untouched.
+TEST(Z84C30, In_OnUnarmedChannelReturnsCounterNotFloatingBus)
+{
+   Z84C30 z84c30;
+
+   unsigned char data = 0xFF;
+   z84c30.In(&data, 0);
+   EXPECT_EQ(data, 0) << "In() left the sentinel value untouched -- floating bus, not a real counter read";
+}


### PR DESCRIPTION
## Bug

`Z84C30::In()` was an empty stub -- it never wrote to `*data`, so any code
reading a CTC channel back got whatever was already in the caller's buffer
instead of the counter's real state. Real Z80 CTC hardware never floats a
channel read: it always answers with the current down-counter value (live
while counting, latched otherwise).

Found while investigating PlayCity, which relies on CTC channel 0 for its
YMZ294 clock -- anything probing the CTC for hardware detection or timing
would have read garbage.

## Fix

`down_counter_` is already kept exactly current by `Tick()` on every call
(CPCCoreEmu's Z84C30 is tick-driven, not timer/attotime-based), so the fix
is a direct read:

```cpp
void Z84C30::In(unsigned char* data, unsigned short address)
{
   *data = channel_[address & 0x3].down_counter_;
}
```

## Proof

Two new tests in `UnitTests/TestZ84C30.cpp`:
- `In_ReturnsLiveDownCounterValue` -- programs channel 0, ticks it down a
  known amount, checks `In()` returns the exact expected count.
- `In_OnUnarmedChannelReturnsCounterNotFloatingBus` -- reads a
  never-programmed channel with a `0xFF` sentinel preloaded into the
  caller's buffer, checks it comes back `0` (the counter's real reset
  value), not the untouched sentinel.

Differential check: reverting the one-line fix makes both new tests fail
with the sentinel value unchanged (`0xFF`), confirming they actually
exercise the bug rather than passing regardless. All 5 `Z84C30.*` tests
pass with the fix applied.

## Reference

Real Z80 CTC channel-read behaviour confirmed against MAME's
`src/devices/machine/z80ctc.cpp` (BSD-3-Clause) -- behavioural reference
only, no code copied. MAME reconstructs the live count from remaining
timer time in its attotime-based model; CPCCoreEmu doesn't need that step
since `down_counter_` is already live on every tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
