### PR TITLE
Fix PlayCity being permanently silent (uninitialised next_call_ymz_)

### DIFF
--- a/CPCCoreEmu/PlayCity.cpp
+++ b/CPCCoreEmu/PlayCity.cpp
@@ -22,6 +22,14 @@ PlayCity::PlayCity(IClockable* int_line, IClockable* nmi_line, /*SoundMixer *mix
    // Channel 3 => ctrl_int
    z84c30_.Init(Z84C30::CHANNEL_3, int_line, nullptr);
    drop_next_tick_ = false;
+   trg0_update_ = false;
+   // Tick() decrements this before testing it against 0, so leaving it
+   // uninitialised here is fatal rather than merely untidy: starting from 0 it
+   // goes straight to -1 and can never come back, and the two YMZ294s are then
+   // never clocked at all -- PlayCity stays completely silent for the whole
+   // session. Reset() sets it too, but Reset() only runs for expansions that
+   // were already plugged in, so a board attached later never got it.
+   next_call_ymz_ = YMZ_CALL;
 }
 
 


### PR DESCRIPTION
## Bug

PlayCity produces **no sound at all**, in any session, even though register
writes reach the YMZ294s correctly.

`PlayCity::Tick()` decrements `next_call_ymz_` and *then* tests it for
equality with zero:

```cpp
--next_call_ymz_;
if (next_call_ymz_ == 0)
{
   ymz294_1_.Tick();
   ymz294_2_.Tick();
   next_call_ymz_ = YMZ_CALL;
}
```

The constructor never initialises `next_call_ymz_`. Only `Reset()` sets it,
and `Reset()` only runs for expansions already present in `exp_list_`, so a
board plugged in after machine init never gets it.

Starting from 0, the counter goes to -1 on the very first tick and keeps
falling, so `== 0` can never match again. Both sound chips are therefore
never clocked for the whole session.

Measured before the fix: **0 YMZ ticks in 36,000,000 PlayCity ticks**, with
`next_call_ymz_` observed at `-35999999`.

## Fix

Initialise `next_call_ymz_` (and `trg0_update_`, uninitialised for the same
reason — it self-corrects since it only toggles, but it should not be read
uninitialised) in the constructor.

## Proof

Rather than rely on a game, the YMZ294 was programmed directly from BASIC —
`OUT &F984`/`&F884` for register select/write — setting the mixer, channel A
volume and tone period, then capturing the core's real PCM output:

| run | result |
|---|---|
| before the fix | total silence, RMS `0.00000000`, both channels |
| after the fix, tone period 254 | **487.2 Hz** + harmonics at 1469 / 2457 / 3432 Hz, RMS 0.704 |
| after the fix, tone period 127 | **982.0 Hz** — ratio **2.016**, the expected doubling for a halved period |
| PlayCity disabled (control) | silent, confirming the tone really comes from the board |

The harmonics sit on 3f / 5f / 7f — the odd-harmonic series of a square wave
— and the fundamental tracks 1/period. Together those confirm genuine tone
generation rather than incidental noise.

The harness was validated independently: the built-in PSG (`SOUND 1,284`)
produces exactly 220.0 Hz through the same capture path, matching
`1 MHz / (16 x 284)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnVjbxoLEetx7Kgu68pUwy