### PR TITLE
Fix PlayCity stereo channels being swapped

### DIFF
--- a/CPCCoreEmu/PlayCity.cpp
+++ b/CPCCoreEmu/PlayCity.cpp
@@ -5,7 +5,8 @@
 #define YMZ_CALL (16>>CLOCK_DIV)
 
 
-PlayCity::PlayCity(IClockable* int_line, IClockable* nmi_line, /*SoundMixer *mixer, */SoundMixer *sound_hub) : ymz294_1_(/*mixer, */YMZ294::LEFT, sound_hub), ymz294_2_(/*mixer,*/ YMZ294::RIGHT, sound_hub), trg0_(this)
+// &F884/&F984 (ymz294_1_) are the right channels, &F888/&F988 the left.
+PlayCity::PlayCity(IClockable* int_line, IClockable* nmi_line, /*SoundMixer *mixer, */SoundMixer *sound_hub) : ymz294_1_(/*mixer, */YMZ294::RIGHT, sound_hub), ymz294_2_(/*mixer,*/ YMZ294::LEFT, sound_hub), trg0_(this)
 {
    // Set the clk from ymz294's to output of CTC channel 0
    inner_line_.AddComponent(&ymz294_1_);


### PR DESCRIPTION
`ymz294_1_` is fed from `&F884`/`&F984` and `ymz294_2_` from `&F888`/`&F988`, per the port decode in `PlayCity::Out()`/`In()`. The first pair is the RIGHT channels on real hardware, but the chips were constructed `YMZ294::LEFT` / `YMZ294::RIGHT` respectively, so the two sides were reversed.

Sources for `&F884`/`&F984` = right:

- CPCWiki, PlayCity page (TotO): "Use the port `$F984` for the right channels and port `$F988` for the left channels", and the same split for `$F884`/`$F888`.
- Arkos Tracker AKY Multi-PSG player, as shipped in OpenTowerDefense, `zik/PlayerAkyMultiPsg.asm:104`: `PLY_AKY_PLAYCITY_SELECTWRITE_PORT_LSB_RIGHT: equ #84`, `..._LSB_LEFT: equ #88`.
- MAME `src/devices/bus/cpc/playcity.cpp`: `m_ymz1` (`&F884`/`&F984`) routes to speaker index 1, `m_ymz2` to index 0.

Two sources disagree: MiSTer `rtl/playcity/playcity.v` (`// addr[2] - left`) and SyX's `supergrafx.i` (`YMZ_WRITE_LEFT EQU $F884`).

Measured, one chip programmed at a time, capturing the core's PCM output:

| ports written | before | after |
|---|---|---|
| `&F884`/`&F984` | left 487.2 Hz, right silent | right 487.2 Hz, left silent |
| `&F888`/`&F988` | — | left 487.0 Hz, right silent |