### PR TITLE
fix(snapshot): correct the CRTC sync flag bits and the PSG register latch

### DIFF
--- a/CPCCoreEmu/Snapshot.cpp
+++ b/CPCCoreEmu/Snapshot.cpp
@@ -383,14 +383,17 @@ void CSnapshot::LoadStdSna ( unsigned char * header, const unsigned char* buffer
    m_pMachine->GetPPI()->m_EntreeCHigh = (( data & 0x08) == 0x08 );
    */
    // PSG
-   machine_->GetPSG()->register_address_ = header[0x5A];
-
    for (int i = 0; i < 16; i++)
    {
       unsigned char data = i;
       machine_->GetPSG()->Access(&data, 3, 0);
       machine_->GetPSG()->Access( &header[0x5B+i], 2, 0);
    }
+
+   // After the replay, not before: the loop above writes the registers through
+   // the bus, and selecting each one latches register_address_ as a side effect,
+   // leaving it at 15.
+   machine_->GetPSG()->register_address_ = header[0x5A];
 
    // Patch with Version 2 if necessary
    if (snaType == 1)
@@ -1486,9 +1489,9 @@ void CSnapshot::WriteSnapshotV3 ( std::vector<unsigned char>& out, unsigned char
    //   CRTC state flags. (note 7)
    //   Bit	 Function
    //   0	 if "1" VSYNC is active, if "0" VSYNC is inactive (note 8)
-   data |= machine_->GetSig()->h_sync_ ?0x01:0;
+   data |= machine_->GetCRTC()->ff4_?0x01:0;
    //   1	 if "1" HSYNC is active, if "0" HSYNC is inactive (note 9)
-   data |= machine_->GetCRTC()->ff4_?0x02:0;
+   data |= machine_->GetSig()->h_sync_ ?0x02:0;
    //   2-7	 reserved
    //   7	 if "1" Vertical Total Adjust is active, if "0" Vertical Total Adjust is inactive (note 10)
    data |= machine_->GetCRTC()->r4_reached_?0x80:0;

--- a/UnitTests/TestSnapshot.cpp
+++ b/UnitTests/TestSnapshot.cpp
@@ -19,7 +19,7 @@ static EmulatorEngine* NewBootedMachine(DirectoriesImp& dirImp, CDisplay& displa
    machine->SetConfigurationManager(&conf_manager);
    machine->Init(&display, &soundFactory);
    machine->GetMem()->Initialisation();
-   machine->LoadConfiguration("./TestConf.ini", "./TestConf_0.ini");
+   machine->LoadConfiguration("6128", "./TestConf.ini");
    machine->Reinit();
    machine->SetFixedSpeed(true);
    machine->SetSpeedLimit(EmulatorEngine::E_FULL);
@@ -96,4 +96,72 @@ TEST(Snapshot, TruncatedImageIsRejected)
    std::vector<unsigned char> half(image.begin(), image.begin() + image.size() / 2);
    machine->LoadSnapshotNow(&half[0], half.size());
    delete machine;
+}
+
+// The PSG register-select latch must come back as it was saved. Restoring the
+// register file replays all 16 registers through the bus, and each write first
+// selects a register, so the latch ends up at 15 -- an assignment made before
+// that loop is simply overwritten.
+TEST(Snapshot, PsgRegisterSelectSurvivesTheRestore)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine = NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, 20);
+
+   std::vector<unsigned char> saved;
+   ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+
+   // Whatever the firmware left selected, as the image actually records it.
+   const unsigned char selected_at_save = saved[0x5A];
+   ASSERT_NE(15, selected_at_save)
+      << "register 15 was selected at save time, so this test cannot tell a "
+         "restored latch from one left behind by the replay loop";
+
+   for (int i = 0; i < 10; ++i)
+      machine->RunTimeSlice();
+
+   ASSERT_TRUE(machine->LoadSnapshotNow(&saved[0], saved.size()));
+   const unsigned char selected_after_restore = machine->GetPSG()->GetRegisterAdress();
+
+   delete machine;
+
+   EXPECT_EQ(selected_at_save, selected_after_restore);
+}
+
+// Byte B0 bit 0 is VSYNC and bit 1 is HSYNC. Writing them the other way round
+// is invisible whenever the two happen to agree, and swaps them whenever they
+// do not -- both within our own round trip, since the load side reads them in
+// the specified order, and for any other emulator reading the image.
+TEST(Snapshot, CrtcSyncFlagsAreSavedInTheirSpecifiedBits)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine = NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, 20);
+
+   bool seen_vsync_and_hsync_differing = false;
+
+   for (int i = 0; i < 120; ++i)
+   {
+      machine->RunTimeSlice();
+
+      std::vector<unsigned char> saved;
+      ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+
+      // Sampled after the save, which advances to an instruction boundary
+      // before building the header.
+      const bool vsync = machine->GetCRTC()->ff4_;          // CRTC drives v_sync_
+      const bool hsync = machine->GetSig()->h_sync_;
+
+      EXPECT_EQ(vsync, (saved[0xB0] & 0x01) != 0) << "B0 bit 0 is VSYNC, slice " << i;
+      EXPECT_EQ(hsync, (saved[0xB0] & 0x02) != 0) << "B0 bit 1 is HSYNC, slice " << i;
+
+      if (vsync != hsync)
+         seen_vsync_and_hsync_differing = true;
+   }
+
+   delete machine;
+
+   ASSERT_TRUE(seen_vsync_and_hsync_differing)
+      << "vsync and hsync agreed in every sample, so a transposed write would "
+         "have passed unnoticed";
 }


### PR DESCRIPTION
Two bugs in the `.SNA` round trip, each with a test that fails without the fix.

Both were found by saving a snapshot on a running machine, letting it run on,
restoring, and then comparing the raw bytes of each component object against a
copy taken at save time. Anything still differing is state the round trip did
not carry.

### Byte B0: the CRTC sync flags were written into each other's bit

The format specifies bit 0 as VSYNC active and bit 1 as HSYNC active. The write
side used the opposite sources:

```c
data |= machine_->GetSig()->h_sync_ ?0x01:0;   // HSYNC written into the VSYNC bit
data |= machine_->GetCRTC()->ff4_?0x02:0;      // VSYNC written into the HSYNC bit
```

`CRTC.cpp` has `signals_->v_sync_ = ff4_;`, so `ff4_` is the vsync flip-flop.
The read side already follows the specification, so the two flags were swapped
on every round trip, and images written here carried them transposed for anyone
else reading them. Fixed on the write side.

### Byte 5A: the PSG register-select latch was overwritten by its own restore

```c
machine_->GetPSG()->register_address_ = header[0x5A];
for (int i = 0; i < 16; i++) { ...Access(&data, 3, 0); ... }
```

The loop replays the registers through the bus, and selecting each one latches
its address, so the latch ended up at 15 whatever the snapshot recorded. Moved
the assignment after the loop.

### Tests

`Snapshot.PsgRegisterSelectSurvivesTheRestore` and
`Snapshot.CrtcSyncFlagsAreSavedInTheirSpecifiedBits`. Without the fixes the
first gets 15 where it expects 7, and the second sees the bits transposed from
the first sample where vsync and hsync differ.

Neither can pass vacuously. The PSG test asserts the recorded latch is not
already 15; the sync test asserts it actually observed a sample where vsync and
hsync differ, since a transposed write is invisible whenever they agree.

Full suite is green before and after: 244 passed, 0 failed, 21 disabled.

There is also a one-line fix to this test file's `NewBootedMachine`.
`LoadConfiguration` takes an ini section name as its first argument, not a path,
so `"./TestConf.ini"` silently fell back to the default configuration rather
than selecting a 6128. My mistake, from #38.

---

@Tom1975 — a separate question I did not want to fold into this PR.

`WriteSnapshotV3` hardcodes the CPC type:

```c
#if 0
   switch ( machine_->GetMachineType()) { ... }
#else
   header[0x6D] = 2;
#endif
```

so every snapshot claims to be a 6128. The read side handles 4, 5 and 6
correctly, so a Plus or GX4000 snapshot comes back as a plain 6128: `plus_` goes
false across Motherboard, Memory, GateArray and CSig, `SetLogicalROM` then takes
the non-plus branch and drops `rom_number_` to 0, and `SetMemoryMap` pages
different banks. Patching it locally to `IsPLUS() ? 4 : 2` takes the Memory and
CSig objects to a byte-exact round trip.

I can see why it is disabled: `GetMachineType()` is on `EmulatorEngine` while
`CSnapshot::machine_` is a `Motherboard*`, so it is not reachable from there.
Mirroring the type onto `Motherboard` would fix it, but that is your API and
your call, so I would rather ask than send a patch.

There is also an interop consequence worth knowing before deciding. cap32 writes
its own model enum straight into this byte, where `CPC_MODEL_PLUS` is 3, and the
specification assigns 3 to "unknown". It also rejects anything above 3
outright:

```c
if (dwModel > CPC_MODEL_MAX) {          // CPC_MODEL_MAX == 3
   emulator_reset(false);
   return ERR_SNA_CPC_TYPE;
}
```

So writing the correct 4, 5 or 6 makes cap32 refuse our Plus snapshots, where
today it accepts them because we claim 6128. That is cap32's enum bound rather
than a disagreement about the format, and cap32 does emulate the Plus, so it is
a real trade-off rather than a theoretical one.

Happy to implement whichever way you prefer, or to leave it alone.
