### PR TITLE
feat(snapshot): record the real CPC type instead of always claiming a 6128

### DIFF
--- a/CPCCoreEmu/Machine.h
+++ b/CPCCoreEmu/Machine.h
@@ -161,8 +161,8 @@ public:
    void Resync ();
    void StartPrecise(unsigned int nb_cycles);
    void UpdateExternalDevices();
-   void SetMachineType(int type) { type_machine_ = type; };
-   int GetMachineType() { return type_machine_; }
+   void SetMachineType(int type) { motherboard_.SetMachineType(type); };
+   int GetMachineType() { return motherboard_.GetMachineType(); }
    void SetPlus(bool plus);
    bool IsPLUS() { return motherboard_.IsPLUS(); }
 
@@ -358,7 +358,6 @@ protected:
    /////////////////////////////////
    // Netlists
 
-   int type_machine_;
    bool do_snapshot_;
    std::string snapshot_file_;
 

--- a/CPCCoreEmu/Motherboard.cpp
+++ b/CPCCoreEmu/Motherboard.cpp
@@ -5,6 +5,7 @@ Motherboard::Motherboard(SoundMixer* sound_mixer, IKeyboardHandler* keyboard_han
    generic_breakpoint_(nullptr),
    supervisor_(nullptr),
    plus_(false),
+   type_machine_(0),
    address_bus_(16), data_bus_(8),
    memory_(&monitor_), 
    keyboardhandler_(keyboard_handler),

--- a/CPCCoreEmu/Motherboard.h
+++ b/CPCCoreEmu/Motherboard.h
@@ -95,6 +95,8 @@ public:
    // Configuration
    void SetPlus(bool plus);
    bool IsPLUS() { return plus_; }
+   void SetMachineType(int type) { type_machine_ = type; }
+   int GetMachineType() { return type_machine_; }
 
    ///////////////////////////////////////
    // Get machine info
@@ -163,6 +165,10 @@ protected:
 
    // Specific configuration
    bool plus_;
+   // MachineSettings::HardwareType. Kept here rather than on EmulatorEngine so
+   // that the components and CSnapshot, which only ever see a Motherboard, can
+   // reach it.
+   int type_machine_;
 
    // Inner hardware
    Bus address_bus_;

--- a/CPCCoreEmu/Snapshot.cpp
+++ b/CPCCoreEmu/Snapshot.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "Snapshot.h"
 #include "Motherboard.h"
+#include "MachineSettings.h"
 #include <stdio.h>
 
 extern unsigned int ListeColorsIndex[0x100];
@@ -410,15 +411,21 @@ void CSnapshot::LoadStdSna ( unsigned char * header, const unsigned char* buffer
    }
    else if (snaType > 2)
    {
-      // CPC Type : To do ?
+      // CPC Type
       switch (header[0x6D])
       {
-      case 0:/*machine_->SetMachineType(0); */machine_->SetPlus(false); break;  // 464
-      case 1:/*machine_->SetMachineType(1); */machine_->SetPlus(false); break;  // 664
-      case 2:/*machine_->SetMachineType(2); */machine_->SetPlus(false); break;  // 6128
-      case 4:/*machine_->SetMachineType(4); */machine_->SetPlus(true); break;  // 6128+
-      case 5:/*machine_->SetMachineType(3); */machine_->SetPlus(true); break;  // 464+
-      case 6:/*machine_->SetMachineType(5); */machine_->SetPlus(true); break;  // GX400
+      case 0:machine_->SetMachineType(MachineSettings::OLD_464);  machine_->SetPlus(false); break;
+      case 1:machine_->SetMachineType(MachineSettings::OLD_664);  machine_->SetPlus(false); break;
+      case 2:machine_->SetMachineType(MachineSettings::OLD_6128); machine_->SetPlus(false); break;
+      // The format defines 3 as "unknown", but every other implementation that
+      // reads this byte treats it as a Plus: it is what Caprice32 writes for its
+      // own Plus model, Arnold's version 3 switch falls through to 6128 Plus,
+      // and CPCEC clamps anything above 3 onto its Plus type. A version 3 image
+      // carrying 3 is a mislabelled Plus snapshot in practice, so follow them.
+      case 3:machine_->SetMachineType(MachineSettings::PLUS_6128);machine_->SetPlus(true); break;
+      case 4:machine_->SetMachineType(MachineSettings::PLUS_6128);machine_->SetPlus(true); break;
+      case 5:machine_->SetMachineType(MachineSettings::PLUS_464); machine_->SetPlus(true); break;
+      case 6:machine_->SetMachineType(MachineSettings::GX400);    machine_->SetPlus(true); break;
       }
 
 
@@ -1422,19 +1429,18 @@ void CSnapshot::WriteSnapshotV3 ( std::vector<unsigned char>& out, unsigned char
       header[0x5B+i] = machine_->GetPSG()->register_[i];
    }
 
-   // CPC Type : To do (6128)?
-#if 0
+   // CPC Type. MachineSettings::HardwareType on the left, the values the
+   // format defines on the right -- the two orders differ for the Plus range.
    switch ( machine_->GetMachineType())
    {
-   case 0:header[0x6D] = 0; break;  // 464
-   case 1:header[0x6D] = 1; break;  // 664
-   case 2:header[0x6D] = 2; break;  // 6128
-   case 3:header[0x6D] = 5; break;  // 464+
-   case 4:header[0x6D] = 4; break;  // 6128+
+   case MachineSettings::OLD_464:  header[0x6D] = 0; break;
+   case MachineSettings::OLD_664:  header[0x6D] = 1; break;
+   case MachineSettings::OLD_6128: header[0x6D] = 2; break;
+   case MachineSettings::PLUS_464: header[0x6D] = 5; break;
+   case MachineSettings::PLUS_6128:header[0x6D] = 4; break;
+   case MachineSettings::GX400:    header[0x6D] = 6; break;
+   default:                        header[0x6D] = 2; break;
    }
-#else
-   header[0x6D] = 2;
-#endif
 
 
    // MemEnable - Bit 7 set if used. Bit 0 = Bank C4..C7, Bit 1 = Banks C4..DF

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable( unitTests
 						   TestUtils.cpp
                      TestZ84C30.cpp
                      TestSnapshot.cpp
+                     TestSnapshotMachineType.cpp
 
 )
 

--- a/UnitTests/TestSnapshotMachineType.cpp
+++ b/UnitTests/TestSnapshotMachineType.cpp
@@ -1,0 +1,137 @@
+#include "gtest/gtest.h"
+
+#include "TestUtils.h"
+#include "MachineSettings.h"
+
+#include <vector>
+
+// Byte 6D of a .SNA records which machine the snapshot was taken on, and the
+// load side acts on it. These cover both directions, plus the one value the
+// format and the other emulators disagree about.
+
+namespace
+{
+
+EmulatorEngine* NewBootedMachine(DirectoriesImp& dirImp, CDisplay& display, Log& log,
+                                 SoundFactory& soundFactory, ConfigurationManager& conf_manager,
+                                 const char* section, int slices)
+{
+   EmulatorEngine* machine = new EmulatorEngine();
+
+   display.Init(false);
+   display.Show(false);
+
+   machine->SetDirectories(&dirImp);
+   machine->SetLog(&log);
+   machine->SetConfigurationManager(&conf_manager);
+   machine->Init(&display, &soundFactory);
+   machine->GetMem()->Initialisation();
+   machine->LoadConfiguration(section, "./TestConf.ini");
+   machine->Reinit();
+   machine->SetFixedSpeed(true);
+   machine->SetSpeedLimit(EmulatorEngine::E_FULL);
+
+   for (int i = 0; i < slices; ++i)
+      machine->RunTimeSlice();
+
+   return machine;
+}
+
+}  // namespace
+
+TEST(SnapshotMachineType, ClassicMachineIsRecordedAsSuch)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128", 20);
+
+   ASSERT_EQ(MachineSettings::OLD_6128, machine->GetMachineType());
+   ASSERT_FALSE(machine->IsPLUS());
+
+   std::vector<unsigned char> saved;
+   ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+   const unsigned char cpc_type = saved[0x6D];
+
+   delete machine;
+
+   EXPECT_EQ(2, cpc_type);
+}
+
+TEST(SnapshotMachineType, PlusMachineIsRecordedAsSuch)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128PLUS", 20);
+
+   ASSERT_EQ(MachineSettings::PLUS_6128, machine->GetMachineType());
+   ASSERT_TRUE(machine->IsPLUS());
+
+   std::vector<unsigned char> saved;
+   ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+   const unsigned char cpc_type = saved[0x6D];
+
+   delete machine;
+
+   // 4 is "6128 Plus" in the format. Recording 2 here, as the writer used to,
+   // makes the load side turn the machine back into a plain 6128.
+   EXPECT_EQ(4, cpc_type);
+}
+
+// The regression this is really about: a Plus snapshot used to come back as a
+// 6128, which also dropped the selected ROM and paged different RAM banks.
+TEST(SnapshotMachineType, PlusMachineIsStillAPlusAfterTheRoundTrip)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128PLUS", 20);
+
+   std::vector<unsigned char> saved;
+   ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+   const unsigned char rom_at_save = machine->GetMem()->GetSelectedRom();
+
+   for (int i = 0; i < 10; ++i)
+      machine->RunTimeSlice();
+
+   ASSERT_TRUE(machine->LoadSnapshotNow(&saved[0], saved.size()));
+
+   const bool plus_after_restore = machine->IsPLUS();
+   const int type_after_restore = machine->GetMachineType();
+   const unsigned char rom_after_restore = machine->GetMem()->GetSelectedRom();
+
+   delete machine;
+
+   EXPECT_TRUE(plus_after_restore);
+   EXPECT_EQ(MachineSettings::PLUS_6128, type_after_restore);
+   EXPECT_EQ(rom_at_save, rom_after_restore);
+}
+
+// The format calls 3 "unknown". Every other implementation that reads this byte
+// takes it as a Plus -- Caprice32 writes 3 for its own Plus model, Arnold's
+// version 3 switch falls through to 6128 Plus, CPCEC clamps anything above 3
+// onto its Plus type -- so an image carrying 3 is a mislabelled Plus snapshot
+// rather than a genuinely unknown machine. This pins that reading, and with it
+// our ability to load Caprice32's Plus snapshots.
+TEST(SnapshotMachineType, UnknownTypeIsTakenAsAPlus)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128", 20);
+
+   std::vector<unsigned char> saved;
+   ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+   ASSERT_EQ(3, saved[0x10]) << "the type byte is only acted on for version 3 images";
+   ASSERT_FALSE(machine->IsPLUS());
+
+   saved[0x6D] = 3;
+   ASSERT_TRUE(machine->LoadSnapshotNow(&saved[0], saved.size()));
+
+   const bool plus_after_restore = machine->IsPLUS();
+
+   delete machine;
+
+   EXPECT_TRUE(plus_after_restore);
+}


### PR DESCRIPTION
Follows up the byte 6D question from #40, with the approach you suggested there.

`WriteSnapshotV3` hardcoded byte 6D to 2, with the switch that computes it
disabled behind `#if 0`. Every snapshot claimed to be a 6128, and since the load
side acts on that byte, a Plus snapshot came back as a plain CPC: `plus_` went
false across Motherboard, Memory, GateArray and CSig, `SetLogicalROM` then took
the non-plus branch and dropped the selected ROM to 0, and `SetMemoryMap` paged
different banks.

### `type_machine_` moved to Motherboard

The switch could not work where it stood: `GetMachineType()` was on
`EmulatorEngine` while `CSnapshot` holds a `Motherboard*`. Moved the field down
next to `plus_`, which it belongs with, and left `EmulatorEngine`'s accessors as
relays — the same shape `IsPLUS()` already had.

The load side now restores the machine type as well as the Plus flag, and both
sides name the `MachineSettings` values rather than using bare numbers: the enum
and the format disagree across the Plus range, 464 Plus being 3 in one and 5 in
the other, which seemed worth spelling out.

### Byte 6D value 3

The format documents 3 as "unknown". Every other implementation that reads this
byte takes it as a Plus: Caprice32 writes 3 for its own Plus model, Arnold's
version 3 switch falls through to 6128 Plus, and CPCEC clamps anything above 3
onto its Plus type. In practice an image carrying 3 is a mislabelled Plus
snapshot rather than a genuinely unknown machine, so it is now read as one. The
comment in the code records that this departs from the letter of the format, and
why.

### Interop

Writing 4, 5 and 6 is what the format specifies and what CPCEC writes
(`header[0x6D]=type_id<3?type_id:ram_depth?4:5`). Arnold reads them, MAME never
looks at the byte.

Caprice32 will now refuse Plus snapshots written here. It compares the field
against its own model enum, whose maximum is 3:

```c
if (dwModel > CPC_MODEL_MAX) {          // CPC_MODEL_MAX == 3
   emulator_reset(false);
   return ERR_SNA_CPC_TYPE;
}
```

Previously it accepted them, because we claimed 6128, and ran Plus software as a
6128. So this trades a silent wrong result for a visible refusal. Flagging it
since it is a real behaviour change for anyone moving images between the two.

### Tests

Four, in a new file. Three fail without the change: the Plus machine records 2
instead of 4, and both round-trip cases come back with `plus_` false. The fourth
pins the classic 6128 case, which was already correct.

Full suite green: 244 passed, 0 failed, 21 disabled.

### Known limitation, not addressed here

`MachineSettings::GX400` is declared but used nowhere in the engine, and
`ChangeConfig` does not handle it — it falls into the `else` branch and gets
`SetPlus(false)` with no cartridge load. `GX4000.cfg` declares `Type=4` and so
comes out as a 6128 Plus, which is why the `GX400` arm of the new switch is
unreachable today. More generally only four `.cfg` files declare `Hardware/Type`
at all and all four say 4, so with the default of `OLD_6128` a snapshot taken on
a 464 still records 2.

That is configuration data and a separate gap in `ChangeConfig` rather than
anything in the snapshot code, so I have left both alone. Happy to open something
for either if you want them fixed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnVjbxoLEetx7Kgu68pUwy
