### PR TITLE
feat(state): a full engine save state, separate from the .SNA

### DIFF
--- a/CPCCoreEmu/CRTC.h
+++ b/CPCCoreEmu/CRTC.h
@@ -10,6 +10,8 @@ class GateArray;
 
 class CRTC : public IComponent
 {
+   friend class MachineState;
+
 friend class EmulatorEngine;
 public:
 

--- a/CPCCoreEmu/ClockLine.h
+++ b/CPCCoreEmu/ClockLine.h
@@ -11,6 +11,8 @@
 ///////
 class CClockLine : public IClockable
 {
+   friend class MachineState;
+
 public:
    CClockLine(void);
    virtual ~CClockLine(void);

--- a/CPCCoreEmu/DMA.h
+++ b/CPCCoreEmu/DMA.h
@@ -14,6 +14,8 @@ class Memory;
 
 class DMA : public IComponent
 {
+   friend class MachineState;
+
 public:
 
    DMA();

--- a/CPCCoreEmu/DiskGen.h
+++ b/CPCCoreEmu/DiskGen.h
@@ -15,6 +15,8 @@
 
 class DiskGen : public ITypeManager
 {
+   friend class MachineState;
+
 public:
 
    using CodageMfm = enum

--- a/CPCCoreEmu/FDC.h
+++ b/CPCCoreEmu/FDC.h
@@ -16,6 +16,8 @@
 
 class CPCCOREEMU_API FDC : public IComponent, public ILoadingProgress
 {
+   friend class MachineState;
+
 friend class EmulatorEngine;
 friend class CSnapshot;
 public:

--- a/CPCCoreEmu/IDisk.h
+++ b/CPCCoreEmu/IDisk.h
@@ -41,6 +41,8 @@
 // IDisk
 class IDisk
 {
+   friend class MachineState;
+
 public:
    enum DiskType
    {

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -55,6 +55,12 @@ const unsigned int kChunkFdc = 0x46444358;  // "FDCX"
 // Restoring a head position into a different disk would seek into nothing.
 const unsigned int kChunkDrives = 0x44525653;  // "DRVS"
 
+// The CRTC. The .SNA carries eighteen of the thirty-two registers and a handful
+// of the counters; the rest keeps whatever the machine happened to boot with,
+// which is invisible while both machines booted the same way and shows up the
+// moment a state crosses into a process that did not.
+const unsigned int kChunkCrtc = 0x43525443;  // "CRTC"
+
 void PutU16(std::vector<unsigned char>& out, unsigned short v)
 {
    out.push_back(v & 0xFF);
@@ -714,6 +720,90 @@ bool MachineState::ReadDrives(Motherboard* board, const unsigned char* p, size_t
    return (at == size);
 }
 
+void MachineState::WriteCrtc(Motherboard* board, std::vector<unsigned char>& out)
+{
+   CRTC* c = board->GetCRTC();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkCrtc);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   out.insert(out.end(), c->registers_list_, c->registers_list_ + 32);
+   out.insert(out.end(), c->registers_mask_, c->registers_mask_ + 32);
+   PutU16(out, c->ma_);
+   PutU16(out, c->bu_);
+   PutU32(out, (unsigned int)c->sscr_bit_8_);
+   out.push_back(c->vlc_);
+   out.push_back(c->adddress_register_);
+   out.push_back(c->status_register_);
+   out.push_back(c->status1_);
+   out.push_back(c->status2_);
+   out.push_back(c->hcc_);
+   out.push_back(c->horinzontal_pulse_);
+   out.push_back(c->vcc_);
+   out.push_back(c->scanline_vbl_);
+   out.push_back(c->vertical_sync_width_);
+   out.push_back(c->horizontal_sync_width_);
+   out.push_back(c->vertical_adjust_counter_);
+   out.push_back(c->r4_reached_ ? 1 : 0);
+   out.push_back(c->ff1_ ? 1 : 0);
+   out.push_back(c->ff3_ ? 1 : 0);
+   out.push_back(c->ff4_ ? 1 : 0);
+   out.push_back(c->mux_ ? 1 : 0);
+   out.push_back(c->mux_set_ ? 1 : 0);
+   out.push_back(c->mux_reset_ ? 1 : 0);
+   out.push_back(c->lightpen_input_ ? 1 : 0);
+   out.push_back(c->r9_triggered_ ? 1 : 0);
+   out.push_back(c->r4_triggered_ ? 1 : 0);
+   out.push_back(c->even_field_ ? 1 : 0);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadCrtc(Motherboard* board, const unsigned char* p, size_t size)
+{
+   CRTC* c = board->GetCRTC();
+   size_t at = 0;
+   // 32 + 32 registers, ma_, bu_, sscr_bit_8_, then twelve bytes and eleven flags.
+   if (size < 95) return false;
+
+   memcpy(c->registers_list_, &p[at], 32); at += 32;
+   memcpy(c->registers_mask_, &p[at], 32); at += 32;
+   c->ma_ = GetU16(&p[at]); at += 2;
+   c->bu_ = GetU16(&p[at]); at += 2;
+   c->sscr_bit_8_ = (int)GetU32(&p[at]); at += 4;
+   c->vlc_ = p[at++];
+   c->adddress_register_ = p[at++];
+   c->status_register_ = p[at++];
+   c->status1_ = p[at++];
+   c->status2_ = p[at++];
+   c->hcc_ = p[at++];
+   c->horinzontal_pulse_ = p[at++];
+   c->vcc_ = p[at++];
+   c->scanline_vbl_ = p[at++];
+   c->vertical_sync_width_ = p[at++];
+   c->horizontal_sync_width_ = p[at++];
+   c->vertical_adjust_counter_ = p[at++];
+   c->r4_reached_ = p[at++] != 0;
+   c->ff1_ = p[at++] != 0;
+   c->ff3_ = p[at++] != 0;
+   c->ff4_ = p[at++] != 0;
+   c->mux_ = p[at++] != 0;
+   c->mux_set_ = p[at++] != 0;
+   c->mux_reset_ = p[at++] != 0;
+   c->lightpen_input_ = p[at++] != 0;
+   c->r9_triggered_ = p[at++] != 0;
+   c->r4_triggered_ = p[at++] != 0;
+   c->even_field_ = p[at++] != 0;
+
+   return (at == size);
+}
+
 bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
 {
    if (machine == nullptr) return false;
@@ -735,6 +825,7 @@ bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out
    WritePsg(machine->GetMotherboard(), out);
    WriteFdc(machine->GetMotherboard(), out);
    WriteDrives(machine->GetMotherboard(), out);
+   WriteCrtc(machine->GetMotherboard(), out);
 
    return true;
 }
@@ -790,6 +881,11 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
       else if (id == kChunkDrives)
       {
          if (!ReadDrives(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkCrtc)
+      {
+         if (!ReadCrtc(machine->GetMotherboard(), &buffer[at], length))
             return false;
       }
       // Unknown chunks are skipped, so a state from a newer build still loads.

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -6,6 +6,8 @@
 #include "IDisk.h"
 #include "Tape.h"
 #include "PPI.h"
+#include "DMA.h"
+#include "PlayCity.h"
 
 #include <cstring>
 
@@ -79,6 +81,20 @@ const unsigned int kChunkTape = 0x54415045;  // "TAPE"
 // sounds, and only visible when the state is loaded into a machine whose own
 // tape level happened to differ.
 const unsigned int kChunkPpi = 0x50504958;  // "PPIX"
+
+// The Plus ASIC's three sound DMA channels. The .SNA's CPC+ chunk carries three
+// of the nine fields each channel has -- the repeat counter, the repeat address
+// and the pause counter -- and not the state machine's current phase, the
+// instruction being executed, or the prescaler. A machine restored mid DMA
+// program therefore resumes somewhere else in it, which is most Plus software
+// with music.
+const unsigned int kChunkDma = 0x444D4158;  // "DMAX"
+
+// PlayCity: two YMZ294 sound chips and a Z84C30 CTC, none of which the .SNA has
+// ever heard of. It is a user-selectable option in the core, so a state taken
+// with it enabled has to carry it or savestates break for everyone who turns it
+// on.
+const unsigned int kChunkPlayCity = 0x50434954;  // "PCIT"
 
 
 void PutU16(std::vector<unsigned char>& out, unsigned short v)
@@ -983,6 +999,182 @@ bool MachineState::ReadPpi(Motherboard* board, const unsigned char* p, size_t si
    return true;
 }
 
+void MachineState::WriteDma(Motherboard* board, std::vector<unsigned char>& out)
+{
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkDma);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   PutU32(out, 3);
+   for (int i = 0; i < 3; ++i)
+   {
+      DMA* d = board->GetDMA(i);
+      PutU32(out, (unsigned int)d->dma_cycle_);
+      PutU32(out, (unsigned int)d->pause_counter_);
+      PutU32(out, (unsigned int)d->repeat_counter_);
+      PutU16(out, d->repeat_addr_);
+      PutU16(out, d->curent_instr_);
+      out.push_back(d->enable_next_ ? 1 : 0);
+      out.push_back(d->ppr_);
+      out.push_back(d->interrupt_on_ ? 1 : 0);
+      out.push_back(d->prescalar_);
+      out.push_back(d->prescalar_counter_);
+   }
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadDma(Motherboard* board, const unsigned char* p, size_t size)
+{
+   size_t at = 0;
+   if (size < 4) return false;
+   if (GetU32(&p[at]) != 3) return false;
+   at += 4;
+   if (size != at + 3 * 21) return false;
+
+   for (int i = 0; i < 3; ++i)
+   {
+      DMA* d = board->GetDMA(i);
+      d->dma_cycle_ = (decltype(d->dma_cycle_))GetU32(&p[at]); at += 4;
+      d->pause_counter_ = (int)GetU32(&p[at]); at += 4;
+      d->repeat_counter_ = (int)GetU32(&p[at]); at += 4;
+      d->repeat_addr_ = GetU16(&p[at]); at += 2;
+      d->curent_instr_ = GetU16(&p[at]); at += 2;
+      d->enable_next_ = p[at++] != 0;
+      d->ppr_ = p[at++];
+      d->interrupt_on_ = p[at++] != 0;
+      d->prescalar_ = p[at++];
+      d->prescalar_counter_ = p[at++];
+   }
+   return true;
+}
+
+void MachineState::WriteYmz(YMZ294* y, std::vector<unsigned char>& out)
+{
+   out.insert(out.end(), y->register_, y->register_ + 16);
+   out.push_back(y->register_address_);
+   PutU32(out, y->channel_a_freq_);   PutU32(out, y->channel_a_freq_counter_);
+   PutU32(out, y->channel_b_freq_);   PutU32(out, y->channel_b_freq_counter_);
+   PutU32(out, y->channel_c_freq_);   PutU32(out, y->channel_c_freq_counter_);
+   PutU32(out, y->noise_frequency_);
+   out.push_back(y->mixer_control_register_);
+   out.push_back(y->channel_a_volume_);
+   out.push_back(y->channel_b_volume_);
+   out.push_back(y->channel_c_volume_);
+   out.push_back(y->envelope_volume_);
+   PutU32(out, y->volume_enveloppe_frequency_);
+   out.push_back(y->volume_enveloppe_shape_);
+   out.push_back(y->up_ ? 1 : 0);
+   out.push_back(y->stop_ ? 1 : 0);
+   PutU32(out, y->counter_a_); PutU32(out, y->counter_b_); PutU32(out, y->counter_c_);
+   PutU32(out, y->counter_noise_); PutU32(out, y->counter_env_); PutU32(out, y->counter_state_env_);
+   out.push_back(y->channel_a_high_); out.push_back(y->channel_b_high_);
+   out.push_back(y->channel_c_high_); out.push_back(y->channel_noise_high_);
+   PutU32(out, y->noise_shift_register_);
+}
+
+void MachineState::ReadYmz(YMZ294* y, const unsigned char* p, size_t& at)
+{
+   memcpy(y->register_, &p[at], 16); at += 16;
+   y->register_address_ = p[at++];
+   y->channel_a_freq_ = GetU32(&p[at]); at += 4; y->channel_a_freq_counter_ = GetU32(&p[at]); at += 4;
+   y->channel_b_freq_ = GetU32(&p[at]); at += 4; y->channel_b_freq_counter_ = GetU32(&p[at]); at += 4;
+   y->channel_c_freq_ = GetU32(&p[at]); at += 4; y->channel_c_freq_counter_ = GetU32(&p[at]); at += 4;
+   y->noise_frequency_ = GetU32(&p[at]); at += 4;
+   y->mixer_control_register_ = p[at++];
+   y->channel_a_volume_ = p[at++]; y->channel_b_volume_ = p[at++]; y->channel_c_volume_ = p[at++];
+   y->envelope_volume_ = p[at++];
+   y->volume_enveloppe_frequency_ = GetU32(&p[at]); at += 4;
+   y->volume_enveloppe_shape_ = p[at++];
+   y->up_ = p[at++] != 0; y->stop_ = p[at++] != 0;
+   y->counter_a_ = GetU32(&p[at]); at += 4; y->counter_b_ = GetU32(&p[at]); at += 4;
+   y->counter_c_ = GetU32(&p[at]); at += 4; y->counter_noise_ = GetU32(&p[at]); at += 4;
+   y->counter_env_ = GetU32(&p[at]); at += 4; y->counter_state_env_ = GetU32(&p[at]); at += 4;
+   y->channel_a_high_ = p[at++]; y->channel_b_high_ = p[at++];
+   y->channel_c_high_ = p[at++]; y->channel_noise_high_ = p[at++];
+   y->noise_shift_register_ = GetU32(&p[at]); at += 4;
+}
+
+void MachineState::WritePlayCity(Motherboard* board, std::vector<unsigned char>& out)
+{
+   PlayCity* pc = board->GetPlayCity();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkPlayCity);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   out.push_back(pc->z84c30_.interrupt_vector_);
+   for (int i = 0; i < 4; ++i)
+   {
+      Z84C30::CTCCounter* ch = &pc->z84c30_.channel_[i];
+      out.push_back(ch->enabled_ ? 1 : 0);
+      out.push_back(ch->control_);
+      out.push_back(ch->time_constant_);
+      out.push_back(ch->down_counter_);
+      out.push_back(ch->prescaler_);
+      out.push_back(ch->decrement_ ? 1 : 0);
+      out.push_back(ch->wait_for_time_constraint_ ? 1 : 0);
+      out.push_back(ch->count_enabled_ ? 1 : 0);
+      out.push_back(ch->reload_ ? 1 : 0);
+   }
+   WriteYmz(&pc->ymz294_1_, out);
+   WriteYmz(&pc->ymz294_2_, out);
+
+   // PlayCity's own timing state, which is not in either chip. next_call_ymz_
+   // in particular is the field whose uninitialised value once made the whole
+   // expansion silent: leaving it out of a state would bring that back on every
+   // restore.
+   out.push_back(pc->trg0_update_ ? 1 : 0);
+   out.push_back(pc->drop_next_tick_ ? 1 : 0);
+   PutU32(out, (unsigned int)pc->next_call_ymz_);
+   out.push_back(pc->inner_line_.signal_up_ ? 1 : 0);
+   out.push_back(pc->inner_line_channel_23_.signal_up_ ? 1 : 0);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadPlayCity(Motherboard* board, const unsigned char* p, size_t size)
+{
+   PlayCity* pc = board->GetPlayCity();
+   size_t at = 0;
+   if (size < 1 + 4 * 9) return false;
+
+   pc->z84c30_.interrupt_vector_ = p[at++];
+   for (int i = 0; i < 4; ++i)
+   {
+      Z84C30::CTCCounter* ch = &pc->z84c30_.channel_[i];
+      ch->enabled_ = p[at++] != 0;
+      ch->control_ = p[at++];
+      ch->time_constant_ = p[at++];
+      ch->down_counter_ = p[at++];
+      ch->prescaler_ = p[at++];
+      ch->decrement_ = p[at++] != 0;
+      ch->wait_for_time_constraint_ = p[at++] != 0;
+      ch->count_enabled_ = p[at++] != 0;
+      ch->reload_ = p[at++] != 0;
+   }
+   ReadYmz(&pc->ymz294_1_, p, at);
+   ReadYmz(&pc->ymz294_2_, p, at);
+
+   pc->trg0_update_ = p[at++] != 0;
+   pc->drop_next_tick_ = p[at++] != 0;
+   pc->next_call_ymz_ = (int)GetU32(&p[at]); at += 4;
+   pc->inner_line_.signal_up_ = p[at++] != 0;
+   pc->inner_line_channel_23_.signal_up_ = p[at++] != 0;
+
+   return (at == size);
+}
+
 bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
 {
    if (machine == nullptr) return false;
@@ -1007,6 +1199,8 @@ bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out
    WriteCrtc(machine->GetMotherboard(), out);
    WriteTape(machine->GetMotherboard(), out);
    WritePpi(machine->GetMotherboard(), out);
+   WriteDma(machine->GetMotherboard(), out);
+   WritePlayCity(machine->GetMotherboard(), out);
 
    return true;
 }
@@ -1077,6 +1271,16 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
       else if (id == kChunkPpi)
       {
          if (!ReadPpi(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkDma)
+      {
+         if (!ReadDma(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkPlayCity)
+      {
+         if (!ReadPlayCity(machine->GetMotherboard(), &buffer[at], length))
             return false;
       }
       // Unknown chunks are skipped, so a state from a newer build still loads.

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -738,7 +738,7 @@ bool MachineState::ReadDrives(Motherboard* board, const unsigned char* p, size_t
 
    for (unsigned int d = 0; d < nb_drives; ++d)
    {
-      if (at + 62 > size) return false;
+      if (at + 68 > size) return false;
       DiskGen* g = &fdc->disk_[d];
       IDisk* disk = g->disk_;
 
@@ -1255,6 +1255,92 @@ bool MachineState::ReadExtendedRam(Motherboard* board, const unsigned char* p, s
    return (at == size);
 }
 
+// Does this state describe the machine it is about to be loaded into?
+//
+// A chunk that refuses halfway through leaves the machine part restored: the
+// .SNA and every chunk before it have already been applied, and the caller is
+// told the load failed while the emulator carries on with a machine that is
+// neither where it was nor where the state wanted it. The frontend shows an
+// error and the user keeps playing something broken.
+//
+// The refusals that happen in practice are the ones about the machine rather
+// than the buffer -- a state from a 576 KB machine on a 128 KB one, from a
+// different disk, a different tape -- so those are checked first, across every
+// chunk, and the load is abandoned before a single byte is written. A size that
+// disagrees means a corrupt buffer, which is a different problem and still
+// fails partway.
+bool MachineState::DescribesThisMachine(Motherboard* board,
+                                        const unsigned char* buffer, size_t size,
+                                        size_t first_chunk)
+{
+   size_t at = first_chunk;
+   while (at + 8 <= size)
+   {
+      const unsigned int id = GetU32(&buffer[at]);
+      const unsigned int length = GetU32(&buffer[at + 4]);
+      at += 8;
+      if (at + length > size) return false;
+
+      const unsigned char* p = &buffer[at];
+
+      if (id == kChunkScheduler)
+      {
+         if (length < 12) return false;
+         if ((int)GetU32(&p[4]) != board->nb_components_) return false;
+      }
+      else if (id == kChunkDrives)
+      {
+         if (length < 4) return false;
+         const unsigned int nb_drives = GetU32(&p[0]);
+         if (nb_drives != (unsigned int)(sizeof(board->GetFDC()->disk_)
+                                       / sizeof(board->GetFDC()->disk_[0]))) return false;
+         size_t d_at = 4;
+         for (unsigned int d = 0; d < nb_drives; ++d)
+         {
+            // Identity, then position: 14 + 32 + 4 + 10 + 8 bytes per drive.
+            const size_t kPerDrive = 68;
+            if (d_at + kPerDrive > length) return false;
+            DiskGen* g = &board->GetFDC()->disk_[d];
+            IDisk* disk = g->disk_;
+            const bool was_present = p[d_at] != 0;
+            const bool had_disk = p[d_at + 1] != 0;
+            const unsigned int sides = GetU32(&p[d_at + 2]);
+            const unsigned int tracks = GetU32(&p[d_at + 6]);
+            if (was_present != g->disk_present_) return false;
+            if (had_disk != (disk != nullptr)) return false;
+            if (disk != nullptr)
+            {
+               if (sides != (unsigned int)disk->GetNumberOfSide()) return false;
+               if (tracks != disk->GetNumberOfTracks()) return false;
+            }
+            d_at += kPerDrive;
+         }
+      }
+      else if (id == kChunkTape)
+      {
+         if (length < 14) return false;
+         CTape* t = board->GetTape();
+         if ((p[0] != 0) != t->is_tape_inserted_) return false;
+         if ((p[1] != 0) != (t->tape_array_ != nullptr)) return false;
+         if (GetU32(&p[2]) != t->nb_inversions_) return false;
+         if (GetU32(&p[6]) != t->array_size_) return false;
+         if (GetU32(&p[10]) != t->nb_blocks_) return false;
+      }
+      else if (id == kChunkExtendedRam)
+      {
+         if (length < 4) return false;
+         unsigned int machine_available = 0;
+         for (int page = 0; page < 8; ++page)
+            if (board->GetMem()->extended_ram_available_[page])
+               machine_available |= (1u << page);
+         if (GetU32(&p[0]) != machine_available) return false;
+      }
+
+      at += length;
+   }
+   return true;
+}
+
 bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
 {
    if (machine == nullptr) return false;
@@ -1295,6 +1381,12 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
 
    const unsigned int sna_size = GetU32(&buffer[8]);
    if (sna_size == 0 || kHeaderSize + sna_size > size) return false;
+
+   // Check what the chunks say about this machine before touching it, so a
+   // state meant for another machine is refused instead of half applied.
+   if (!DescribesThisMachine(machine->GetMotherboard(), buffer, size,
+                             kHeaderSize + sna_size))
+      return false;
 
    // The .SNA goes in first: it resets and repopulates the components, so
    // anything the chunks restore has to be applied after it.

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -1,0 +1,801 @@
+#include "stdafx.h"
+#include "MachineState.h"
+#include "Machine.h"
+#include "Motherboard.h"
+#include "DiskGen.h"
+#include "IDisk.h"
+
+#include <cstring>
+
+namespace
+{
+
+const unsigned char kMagic[4] = { 'S', 'B', 'X', 'S' };
+const size_t kHeaderSize = 12;
+
+// Scheduler: the cycle debt each component carries across a time slice, which
+// is what a .SNA has no room for and what makes a restored machine drift.
+const unsigned int kChunkScheduler = 0x53434844;  // "SCHD"
+
+// The CPU's execution engine: where it is inside the current instruction, and
+// the latches it carries between machine cycles. A .SNA only records the
+// registers an instruction boundary can see.
+const unsigned int kChunkZ80 = 0x5A383058;  // "Z80X"
+
+// The gate array's own counters. The .SNA has fields for the interrupt counter
+// and the vsync delay, but none for the hsync counter that drives them, so a
+// restored machine raises its next interrupt at a different moment.
+const unsigned int kChunkGateArray = 0x47415258;  // "GARX"
+
+// The sound chip's derived state. A .SNA carries the sixteen registers and the
+// load side replays them through the bus, which rebuilds most of this -- but
+// replaying r13 restarts the envelope and replaying r14 clears the flag that
+// selects the keyboard rather than the latch, so the machine reads different
+// keys after a restore and takes a different path.
+const unsigned int kChunkPsg = 0x50534758;  // "PSGX"
+
+// The disk controller: the command in flight with its parameters and results,
+// the head position, and the MFM decoder's place in the track. A .SNA has room
+// for the motor flag and the current track and nothing else, which describes a
+// stopped drive and no more.
+//
+// scan_func_, disk_to_load_ and delayed_load_filepath_ are deliberately left
+// out. The first is a function pointer and the others belong to the deferred
+// disk-load request rather than to the controller, and writing a host address
+// into a state that another process will read back is a bug, not an omission.
+const unsigned int kChunkFdc = 0x46444358;  // "FDCX"
+
+// The drives: where each head is, not what is under it.
+//
+// A disk image is media, not machine state. It can be hundreds of kilobytes,
+// it is the same before and after, and the user may legitimately have swapped
+// it. So this carries the position -- track, side, rotational angle, and the
+// MFM decoder's place in the bit stream -- and refuses to load if the geometry
+// of the disk now in the drive does not match the one the state was taken with.
+// Restoring a head position into a different disk would seek into nothing.
+const unsigned int kChunkDrives = 0x44525653;  // "DRVS"
+
+void PutU16(std::vector<unsigned char>& out, unsigned short v)
+{
+   out.push_back(v & 0xFF);
+   out.push_back((v >> 8) & 0xFF);
+}
+
+void PutU32(std::vector<unsigned char>& out, unsigned int v)
+{
+   out.push_back(v & 0xFF);
+   out.push_back((v >> 8) & 0xFF);
+   out.push_back((v >> 16) & 0xFF);
+   out.push_back((v >> 24) & 0xFF);
+}
+
+unsigned short GetU16(const unsigned char* p) { return p[0] | (p[1] << 8); }
+
+unsigned int GetU32(const unsigned char* p)
+{
+   return p[0] | (p[1] << 8) | (p[2] << 16) | ((unsigned int)p[3] << 24);
+}
+
+}  // namespace
+
+void MachineState::WriteScheduler(Motherboard* board, std::vector<unsigned char>& out)
+{
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkScheduler);
+   PutU32(out, 0);                       // patched once the payload is known
+
+   const size_t payload_at = out.size();
+
+   PutU32(out, board->counter_);
+   PutU32(out, (unsigned int)board->nb_components_);
+
+   const int nb_elapsed = (int)(sizeof(board->component_elapsed_time_)
+                              / sizeof(board->component_elapsed_time_[0]));
+   PutU32(out, (unsigned int)nb_elapsed);
+   for (int i = 0; i < nb_elapsed; ++i)
+      PutU32(out, board->component_elapsed_time_[i]);
+
+   // Each component keeps its own copy of where it is within the slice.
+   for (int i = 0; i < board->nb_components_; ++i)
+   {
+      IComponent* c = board->component_list_[i];
+      PutU32(out, c ? (unsigned int)c->elapsed_time_ : 0);
+      PutU32(out, c ? (unsigned int)c->this_tick_time_ : 0);
+   }
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadScheduler(Motherboard* board, const unsigned char* p, size_t size)
+{
+   if (size < 12) return false;
+   size_t at = 0;
+
+   board->counter_ = GetU32(&p[at]); at += 4;
+
+   const int nb_components = (int)GetU32(&p[at]); at += 4;
+   const int nb_elapsed = (int)GetU32(&p[at]); at += 4;
+
+   const int capacity_elapsed = (int)(sizeof(board->component_elapsed_time_)
+                                    / sizeof(board->component_elapsed_time_[0]));
+   const int capacity_components = (int)(sizeof(board->component_list_)
+                                       / sizeof(board->component_list_[0]));
+   if (nb_elapsed != capacity_elapsed) return false;
+   if (nb_components < 0 || nb_components > capacity_components) return false;
+   if (size < at + (size_t)nb_elapsed * 4 + (size_t)nb_components * 8) return false;
+
+   // nb_components_ itself is set by InitStartOptimized() from the machine's
+   // configuration, not by the state: a state must not be able to describe a
+   // component list that does not match the machine it is loaded into.
+   if (nb_components != board->nb_components_) return false;
+
+   for (int i = 0; i < nb_elapsed; ++i)
+   {
+      board->component_elapsed_time_[i] = GetU32(&p[at]); at += 4;
+   }
+
+   for (int i = 0; i < nb_components; ++i)
+   {
+      IComponent* c = board->component_list_[i];
+      const unsigned int elapsed = GetU32(&p[at]); at += 4;
+      const unsigned int tick = GetU32(&p[at]); at += 4;
+      if (c)
+      {
+         c->elapsed_time_ = (int)elapsed;
+         c->this_tick_time_ = (int)tick;
+      }
+   }
+
+   return true;
+}
+
+void MachineState::WriteZ80(Motherboard* board, std::vector<unsigned char>& out)
+{
+   Z80* z80 = board->GetProc();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkZ80);
+   PutU32(out, 0);                       // patched once the payload is known
+   const size_t payload_at = out.size();
+
+   PutU32(out, z80->current_opcode_);
+   PutU32(out, (unsigned int)z80->t_);
+   PutU32(out, (unsigned int)z80->machine_cycle_);
+   PutU32(out, z80->counter_);
+   PutU32(out, z80->read_count_);
+   PutU16(out, z80->address_);
+   PutU16(out, z80->current_address_);
+   PutU16(out, z80->current_data_);
+   PutU16(out, z80->mem_ptr_.w);
+   out.push_back(z80->data_);
+   out.push_back(z80->q_);
+   out.push_back(z80->new_instruction_ ? 1 : 0);
+   out.push_back(z80->rw_opcode_ ? 1 : 0);
+   out.push_back(z80->carry_set_ ? 1 : 0);
+   out.push_back(z80->break_ ? 1 : 0);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadZ80(Motherboard* board, const unsigned char* p, size_t size)
+{
+   if (size < 34) return false;
+   Z80* z80 = board->GetProc();
+   size_t at = 0;
+
+   // current_function_ and next_function_ are pointers into the CPU's own
+   // dispatch tables, so they cannot be written to a buffer and read back in
+   // another process. They do not have to be: a state is only ever taken on an
+   // instruction boundary, where the pending function is always the fetch, so
+   // put the CPU back in that canonical state and let the fields below say
+   // where inside the fetch it was. pc_ has already been restored from the
+   // .SNA at this point, so this preserves it.
+   z80->PrepareForFetch(z80->pc_);
+
+   z80->current_opcode_ = GetU32(&p[at]); at += 4;
+   z80->t_ = (int)GetU32(&p[at]); at += 4;
+   z80->machine_cycle_ = (Z80::MachineCycle)GetU32(&p[at]); at += 4;
+   z80->counter_ = GetU32(&p[at]); at += 4;
+   z80->read_count_ = GetU32(&p[at]); at += 4;
+   z80->address_ = GetU16(&p[at]); at += 2;
+   z80->current_address_ = GetU16(&p[at]); at += 2;
+   z80->current_data_ = GetU16(&p[at]); at += 2;
+   z80->mem_ptr_.w = GetU16(&p[at]); at += 2;
+   z80->data_ = p[at++];
+   z80->q_ = p[at++];
+   z80->new_instruction_ = p[at++] != 0;
+   z80->rw_opcode_ = p[at++] != 0;
+   z80->carry_set_ = p[at++] != 0;
+   z80->break_ = p[at++] != 0;
+
+   return true;
+}
+
+void MachineState::WriteGateArray(Motherboard* board, std::vector<unsigned char>& out)
+{
+   GateArray* ga = board->GetVGA();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkGateArray);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   out.push_back(ga->hsync_counter_);
+   out.push_back(ga->vsync_counter_);
+   out.push_back(ga->interrupt_counter_);
+   out.push_back(ga->wait_for_hsync_);
+   out.push_back(ga->interrupt_raised_ ? 1 : 0);
+   out.push_back(ga->hsync_ ? 1 : 0);
+   out.push_back(ga->vsync_ ? 1 : 0);
+   out.push_back(ga->h_old_sync_ ? 1 : 0);
+   out.push_back(ga->v_old_sync_ ? 1 : 0);
+   // A palette write can be pending when the state is taken.
+   out.push_back(ga->buffered_ink_available_ ? 1 : 0);
+   PutU32(out, ga->buffered_ink_);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadGateArray(Motherboard* board, const unsigned char* p, size_t size)
+{
+   if (size < 14) return false;
+   GateArray* ga = board->GetVGA();
+   size_t at = 0;
+
+   ga->hsync_counter_ = p[at++];
+   ga->vsync_counter_ = p[at++];
+   ga->interrupt_counter_ = p[at++];
+   ga->wait_for_hsync_ = p[at++];
+   ga->interrupt_raised_ = p[at++] != 0;
+   ga->hsync_ = p[at++] != 0;
+   ga->vsync_ = p[at++] != 0;
+   ga->h_old_sync_ = p[at++] != 0;
+   ga->v_old_sync_ = p[at++] != 0;
+   ga->buffered_ink_available_ = p[at++] != 0;
+   ga->buffered_ink_ = GetU32(&p[at]); at += 4;
+
+   return true;
+}
+
+void MachineState::WritePsg(Motherboard* board, std::vector<unsigned char>& out)
+{
+   Ay8912* psg = board->GetPSG();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkPsg);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   out.insert(out.end(), psg->register_, psg->register_ + 16);
+   out.push_back(psg->register_address_);
+
+   PutU32(out, psg->channel_a_freq_);   PutU32(out, psg->channel_a_freq_counter_);
+   PutU32(out, psg->channel_b_freq_);   PutU32(out, psg->channel_b_freq_counter_);
+   PutU32(out, psg->channel_c_freq_);   PutU32(out, psg->channel_c_freq_counter_);
+   PutU32(out, psg->noise_frequency_);
+
+   out.push_back(psg->mixer_control_register_);
+   out.push_back(psg->channel_a_volume_);
+   out.push_back(psg->channel_b_volume_);
+   out.push_back(psg->channel_c_volume_);
+   out.push_back(psg->enveloppe_volume_);
+   PutU32(out, psg->volume_enveloppe_frequency_);
+   out.push_back(psg->volume_enveloppe_shape_);
+   out.push_back(psg->external_data_register_b_);
+   out.push_back(psg->enveloppe_up_ ? 1 : 0);
+   out.push_back(psg->enveloppe_stop_ ? 1 : 0);
+   out.push_back(psg->register_replaced_ ? 1 : 0);
+   out.push_back(psg->register_14_);
+
+   PutU32(out, psg->counter_a_);
+   PutU32(out, psg->counter_b_);
+   PutU32(out, psg->counter_c_);
+   PutU32(out, psg->counter_noise_);
+   PutU32(out, psg->counter_env_);
+   PutU32(out, psg->counter_state_env_);
+   out.push_back(psg->chan_a_high_);
+   out.push_back(psg->chan_b_high_);
+   out.push_back(psg->chan_c_high_);
+   out.push_back(psg->chan_noise_high_);
+   PutU32(out, psg->noise_shift_register_);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadPsg(Motherboard* board, const unsigned char* p, size_t size)
+{
+   if (size < 85) return false;
+   Ay8912* psg = board->GetPSG();
+   size_t at = 0;
+
+   memcpy(psg->register_, &p[at], 16); at += 16;
+   psg->register_address_ = p[at++];
+
+   psg->channel_a_freq_ = GetU32(&p[at]); at += 4;
+   psg->channel_a_freq_counter_ = GetU32(&p[at]); at += 4;
+   psg->channel_b_freq_ = GetU32(&p[at]); at += 4;
+   psg->channel_b_freq_counter_ = GetU32(&p[at]); at += 4;
+   psg->channel_c_freq_ = GetU32(&p[at]); at += 4;
+   psg->channel_c_freq_counter_ = GetU32(&p[at]); at += 4;
+   psg->noise_frequency_ = GetU32(&p[at]); at += 4;
+
+   psg->mixer_control_register_ = p[at++];
+   psg->channel_a_volume_ = p[at++];
+   psg->channel_b_volume_ = p[at++];
+   psg->channel_c_volume_ = p[at++];
+   psg->enveloppe_volume_ = p[at++];
+   psg->volume_enveloppe_frequency_ = GetU32(&p[at]); at += 4;
+   psg->volume_enveloppe_shape_ = p[at++];
+   psg->external_data_register_b_ = p[at++];
+   psg->enveloppe_up_ = p[at++] != 0;
+   psg->enveloppe_stop_ = p[at++] != 0;
+   psg->register_replaced_ = p[at++] != 0;
+   psg->register_14_ = p[at++];
+
+   psg->counter_a_ = GetU32(&p[at]); at += 4;
+   psg->counter_b_ = GetU32(&p[at]); at += 4;
+   psg->counter_c_ = GetU32(&p[at]); at += 4;
+   psg->counter_noise_ = GetU32(&p[at]); at += 4;
+   psg->counter_env_ = GetU32(&p[at]); at += 4;
+   psg->counter_state_env_ = GetU32(&p[at]); at += 4;
+   psg->chan_a_high_ = p[at++];
+   psg->chan_b_high_ = p[at++];
+   psg->chan_c_high_ = p[at++];
+   psg->chan_noise_high_ = p[at++];
+   psg->noise_shift_register_ = GetU32(&p[at]); at += 4;
+
+   return true;
+}
+
+void MachineState::WriteFdc(Motherboard* board, std::vector<unsigned char>& out)
+{
+   FDC* f = board->GetFDC();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkFdc);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   PutU32(out, (unsigned int)f->state_);
+   out.push_back(f->instruction_);
+   out.push_back(f->mt_ ? 1 : 0);
+   out.push_back(f->mf_ ? 1 : 0);
+   out.push_back(f->sk_ ? 1 : 0);
+   out.push_back(f->motor_on_ ? 1 : 0);
+   out.push_back(f->first_sector_found_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->sector_count_);
+   PutU32(out, (unsigned int)f->nb_data_in_buffer_);
+   PutU32(out, (unsigned int)f->nb_data_offset_);
+   out.insert(out.end(), f->data_buffer_, f->data_buffer_ + 1);
+   out.push_back(f->recalibrate_ ? 1 : 0);
+   out.insert(out.end(), f->parameters_, f->parameters_ + 9);
+   out.insert(out.end(), f->results_, f->results_ + 7);
+   out.push_back(f->parameters_count_);
+   out.push_back(f->results_count_);
+   PutU32(out, (unsigned int)f->index_fdc_command_);
+   PutU32(out, (unsigned int)f->step_rate_);
+   out.push_back(f->track_seeded_);
+   out.push_back(f->step_count_);
+   PutU32(out, (unsigned int)f->move_size_);
+   out.push_back(f->dma_disable_ ? 1 : 0);
+   out.push_back(f->ma_ ? 1 : 0);
+   out.push_back(f->nw_ ? 1 : 0);
+   out.push_back(f->nd_ ? 1 : 0);
+   out.push_back(f->or_ ? 1 : 0);
+   out.push_back(f->de_ ? 1 : 0);
+   out.push_back(f->en_ ? 1 : 0);
+   out.push_back(f->status_0_);
+   out.push_back(f->status_1_);
+   out.push_back(f->status_2_);
+   out.push_back(f->status_3_);
+   out.push_back(f->hu_);
+   out.push_back(f->tp_);
+   out.push_back(f->tr_);
+   out.push_back(f->hd_);
+   out.push_back(f->sc_);
+   out.push_back(f->init_r_);
+   out.push_back(f->sz_);
+   out.push_back(f->ls_);
+   out.push_back(f->gp_);
+   out.push_back(f->sl_);
+   out.push_back(f->fb_);
+   out.push_back(f->nm_);
+   out.push_back(f->seek_cmd_ ? 1 : 0);
+   out.push_back(f->interrupt_code_);
+   out.push_back(f->seek_end_ ? 1 : 0);
+   out.push_back(f->force_nd_ ? 1 : 0);
+   out.push_back(f->last_interrupt_result_);
+   out.push_back(f->interrupt_occured_ ? 1 : 0);
+   out.push_back(f->ready_line_changed_ ? 1 : 0);
+   out.push_back(f->busy_);
+   out.push_back(f->main_status_);
+   out.push_back(f->data_register_);
+   out.push_back(f->cb_ ? 1 : 0);
+   out.push_back(f->rqm_ ? 1 : 0);
+   out.push_back(f->dio_ ? 1 : 0);
+   out.push_back(f->exm_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->delay_for_instruction_);
+   PutU32(out, (unsigned int)(f->time_ & 0xFFFFFFFFu)); PutU32(out, (unsigned int)(f->time_ >> 32));
+   PutU32(out, (unsigned int)(f->time_for_bad_instruction_ & 0xFFFFFFFFu)); PutU32(out, (unsigned int)(f->time_for_bad_instruction_ >> 32));
+   out.push_back(f->rw_command_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->cnt_exec_);
+   PutU32(out, (unsigned int)f->old_state_);
+   PutU32(out, (unsigned int)f->current_command_);
+   PutU32(out, (unsigned int)f->index_hole_encountered_);
+   out.push_back(f->read_deleted_ ? 1 : 0);
+   out.push_back(f->write_deleted_ ? 1 : 0);
+   out.push_back(f->tc_ ? 1 : 0);
+   PutU16(out, (unsigned short)f->read_crc_);
+   out.push_back(f->seek_track_ ? 1 : 0);
+   out.push_back(f->stp_);
+   PutU32(out, (unsigned int)f->format_phase_);
+   PutU32(out, (unsigned int)f->format_sector_count_);
+   PutU32(out, (unsigned int)f->seek_count_);
+   out.insert(out.end(), f->sc_array_, f->sc_array_ + 2);
+   PutU32(out, (unsigned int)f->current_drive_);
+   PutU32(out, (unsigned int)f->current_command_phase_);
+   out.push_back(f->previous_bit_);
+   out.push_back(f->sync_count_);
+   out.push_back(f->current_data_byte_);
+   out.push_back(f->bit_count_);
+   PutU32(out, (unsigned int)f->out_index_);
+   PutU32(out, (unsigned int)f->data_to_read_);
+   PutU32(out, (unsigned int)f->data_to_return_);
+   out.push_back(f->first_non_0_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->read_sector_state_);
+   out.push_back(f->read_track_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->write_byte_counter_);
+   out.push_back(f->byte_to_write_);
+   out.push_back(f->byte_is_sync_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->next_phase_);
+   out.push_back(f->crc_on_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->chrn_byte_count_);
+   PutU32(out, (unsigned int)f->crc_cyte_);
+   out.push_back(f->delayed_load_ ? 1 : 0);
+   PutU32(out, (unsigned int)f->delayed_load_count_);
+   PutU32(out, (unsigned int)f->delayed_load_drive_);
+   out.push_back(f->delayed_load_container_ ? 1 : 0);
+   out.push_back(f->on_index_ ? 1 : 0);
+   out.push_back(f->read_data_done_ ? 1 : 0);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadFdc(Motherboard* board, const unsigned char* p, size_t size)
+{
+   FDC* f = board->GetFDC();
+   size_t at = 0;
+
+   f->state_ = (FDC::Phase)GetU32(&p[at]); at += 4;
+   f->instruction_ = p[at++];
+   f->mt_ = p[at++] != 0;
+   f->mf_ = p[at++] != 0;
+   f->sk_ = p[at++] != 0;
+   f->motor_on_ = p[at++] != 0;
+   f->first_sector_found_ = p[at++] != 0;
+   f->sector_count_ = GetU32(&p[at]); at += 4;
+   f->nb_data_in_buffer_ = GetU32(&p[at]); at += 4;
+   f->nb_data_offset_ = GetU32(&p[at]); at += 4;
+   memcpy(f->data_buffer_, &p[at], 1); at += 1;
+   f->recalibrate_ = p[at++] != 0;
+   memcpy(f->parameters_, &p[at], 9); at += 9;
+   memcpy(f->results_, &p[at], 7); at += 7;
+   f->parameters_count_ = p[at++];
+   f->results_count_ = p[at++];
+   f->index_fdc_command_ = GetU32(&p[at]); at += 4;
+   f->step_rate_ = GetU32(&p[at]); at += 4;
+   f->track_seeded_ = p[at++];
+   f->step_count_ = p[at++];
+   f->move_size_ = GetU32(&p[at]); at += 4;
+   f->dma_disable_ = p[at++] != 0;
+   f->ma_ = p[at++] != 0;
+   f->nw_ = p[at++] != 0;
+   f->nd_ = p[at++] != 0;
+   f->or_ = p[at++] != 0;
+   f->de_ = p[at++] != 0;
+   f->en_ = p[at++] != 0;
+   f->status_0_ = p[at++];
+   f->status_1_ = p[at++];
+   f->status_2_ = p[at++];
+   f->status_3_ = p[at++];
+   f->hu_ = p[at++];
+   f->tp_ = p[at++];
+   f->tr_ = p[at++];
+   f->hd_ = p[at++];
+   f->sc_ = p[at++];
+   f->init_r_ = p[at++];
+   f->sz_ = p[at++];
+   f->ls_ = p[at++];
+   f->gp_ = p[at++];
+   f->sl_ = p[at++];
+   f->fb_ = p[at++];
+   f->nm_ = p[at++];
+   f->seek_cmd_ = p[at++] != 0;
+   f->interrupt_code_ = p[at++];
+   f->seek_end_ = p[at++] != 0;
+   f->force_nd_ = p[at++] != 0;
+   f->last_interrupt_result_ = p[at++];
+   f->interrupt_occured_ = p[at++] != 0;
+   f->ready_line_changed_ = p[at++] != 0;
+   f->busy_ = p[at++];
+   f->main_status_ = p[at++];
+   f->data_register_ = p[at++];
+   f->cb_ = p[at++] != 0;
+   f->rqm_ = p[at++] != 0;
+   f->dio_ = p[at++] != 0;
+   f->exm_ = p[at++] != 0;
+   f->delay_for_instruction_ = GetU32(&p[at]); at += 4;
+   f->time_ = GetU32(&p[at]) | ((uint64_t)GetU32(&p[at+4]) << 32); at += 8;
+   f->time_for_bad_instruction_ = GetU32(&p[at]) | ((uint64_t)GetU32(&p[at+4]) << 32); at += 8;
+   f->rw_command_ = p[at++] != 0;
+   f->cnt_exec_ = GetU32(&p[at]); at += 4;
+   f->old_state_ = (FDC::Phase)GetU32(&p[at]); at += 4;
+   f->current_command_ = (FDC::Commands)GetU32(&p[at]); at += 4;
+   f->index_hole_encountered_ = GetU32(&p[at]); at += 4;
+   f->read_deleted_ = p[at++] != 0;
+   f->write_deleted_ = p[at++] != 0;
+   f->tc_ = p[at++] != 0;
+   f->read_crc_ = GetU16(&p[at]); at += 2;
+   f->seek_track_ = p[at++] != 0;
+   f->stp_ = p[at++];
+   f->format_phase_ = (FDC::MFMPhase)GetU32(&p[at]); at += 4;
+   f->format_sector_count_ = GetU32(&p[at]); at += 4;
+   f->seek_count_ = GetU32(&p[at]); at += 4;
+   memcpy(f->sc_array_, &p[at], 2); at += 2;
+   f->current_drive_ = GetU32(&p[at]); at += 4;
+   f->current_command_phase_ = (FDC::SectorPhase)GetU32(&p[at]); at += 4;
+   f->previous_bit_ = p[at++];
+   f->sync_count_ = p[at++];
+   f->current_data_byte_ = p[at++];
+   f->bit_count_ = p[at++];
+   f->out_index_ = GetU32(&p[at]); at += 4;
+   f->data_to_read_ = GetU32(&p[at]); at += 4;
+   f->data_to_return_ = GetU32(&p[at]); at += 4;
+   f->first_non_0_ = p[at++] != 0;
+   f->read_sector_state_ = GetU32(&p[at]); at += 4;
+   f->read_track_ = p[at++] != 0;
+   f->write_byte_counter_ = GetU32(&p[at]); at += 4;
+   f->byte_to_write_ = p[at++];
+   f->byte_is_sync_ = p[at++] != 0;
+   f->next_phase_ = (FDC::MFMPhase)GetU32(&p[at]); at += 4;
+   f->crc_on_ = p[at++] != 0;
+   f->chrn_byte_count_ = GetU32(&p[at]); at += 4;
+   f->crc_cyte_ = GetU32(&p[at]); at += 4;
+   f->delayed_load_ = p[at++] != 0;
+   f->delayed_load_count_ = GetU32(&p[at]); at += 4;
+   f->delayed_load_drive_ = GetU32(&p[at]); at += 4;
+   f->delayed_load_container_ = p[at++] != 0;
+   f->on_index_ = p[at++] != 0;
+   f->read_data_done_ = p[at++] != 0;
+
+   // Writer and reader must agree byte for byte; if they ever drift apart this
+   // catches it here rather than in a machine that quietly runs wrong.
+   return (at == size);
+}
+
+void MachineState::WriteDrives(Motherboard* board, std::vector<unsigned char>& out)
+{
+   FDC* fdc = board->GetFDC();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkDrives);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   const unsigned int nb_drives = (unsigned int)(sizeof(fdc->disk_) / sizeof(fdc->disk_[0]));
+   PutU32(out, nb_drives);
+
+   for (unsigned int d = 0; d < nb_drives; ++d)
+   {
+      DiskGen* g = &fdc->disk_[d];
+
+      // Identity of the media, so the reader can refuse a mismatch.
+      IDisk* disk = g->disk_;
+      out.push_back(g->disk_present_ ? 1 : 0);
+      out.push_back(disk ? 1 : 0);
+      PutU32(out, disk ? (unsigned int)disk->GetNumberOfSide() : 0);
+      PutU32(out, disk ? disk->GetNumberOfTracks() : 0);
+
+      // Position within that media.
+      PutU32(out, disk ? disk->head_position_ : 0);
+
+      PutU32(out, (unsigned int)g->encode_scheme_);
+      PutU32(out, (unsigned int)g->current_side_);
+      PutU32(out, g->current_track_);
+      PutU32(out, g->side_0_number_);
+      PutU32(out, (unsigned int)g->write_bit_);
+      PutU32(out, (unsigned int)g->current_speed_);
+      PutU32(out, (unsigned int)g->final_speed_);
+      PutU32(out, (unsigned int)g->speed_change_counter_);
+      PutU16(out, g->byte_to_write_);
+      PutU16(out, g->current_mfm_byte_);
+      out.push_back(g->on_index_hole_ ? 1 : 0);
+      out.push_back(g->write_protection_on_ ? 1 : 0);
+      out.push_back(g->fixed_speed_ ? 1 : 0);
+      out.push_back(g->read_ ? 1 : 0);
+      out.push_back(g->sync_write_ ? 1 : 0);
+      out.push_back(g->sync_found_ ? 1 : 0);
+      out.push_back(g->byte_ready_ ? 1 : 0);
+      out.push_back(g->data_bit_ ? 1 : 0);
+      out.push_back(g->motor_on_ ? 1 : 0);
+      out.push_back(g->new_bit_available_ ? 1 : 0);
+
+      // Floats go out as their bits: a decimal round trip would not come back
+      // to the same value, and the timing depends on the exact one.
+      unsigned int bits;
+      memcpy(&bits, &g->time_for_one_bit_, 4); PutU32(out, bits);
+      memcpy(&bits, &g->timer_count_, 4);      PutU32(out, bits);
+   }
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadDrives(Motherboard* board, const unsigned char* p, size_t size)
+{
+   FDC* fdc = board->GetFDC();
+   size_t at = 0;
+   if (size < 4) return false;
+
+   const unsigned int nb_drives = GetU32(&p[at]); at += 4;
+   if (nb_drives != (unsigned int)(sizeof(fdc->disk_) / sizeof(fdc->disk_[0]))) return false;
+
+   for (unsigned int d = 0; d < nb_drives; ++d)
+   {
+      if (at + 62 > size) return false;
+      DiskGen* g = &fdc->disk_[d];
+      IDisk* disk = g->disk_;
+
+      const bool was_present = p[at++] != 0;
+      const bool had_disk = p[at++] != 0;
+      const unsigned int sides = GetU32(&p[at]); at += 4;
+      const unsigned int tracks = GetU32(&p[at]); at += 4;
+      const unsigned int head_position = GetU32(&p[at]); at += 4;
+
+      // Refuse rather than seek into a disk that is not the one described.
+      if (was_present != g->disk_present_) return false;
+      if (had_disk != (disk != nullptr)) return false;
+      if (disk != nullptr)
+      {
+         if (sides != (unsigned int)disk->GetNumberOfSide()) return false;
+         if (tracks != disk->GetNumberOfTracks()) return false;
+         disk->head_position_ = head_position;
+      }
+
+      g->encode_scheme_ = (DiskGen::CodageMfm)GetU32(&p[at]); at += 4;
+      g->current_side_ = (int)GetU32(&p[at]); at += 4;
+      g->current_track_ = GetU32(&p[at]); at += 4;
+      g->side_0_number_ = GetU32(&p[at]); at += 4;
+      g->write_bit_ = (int)GetU32(&p[at]); at += 4;
+      g->current_speed_ = (int)GetU32(&p[at]); at += 4;
+      g->final_speed_ = (int)GetU32(&p[at]); at += 4;
+      g->speed_change_counter_ = (int)GetU32(&p[at]); at += 4;
+      g->byte_to_write_ = GetU16(&p[at]); at += 2;
+      g->current_mfm_byte_ = GetU16(&p[at]); at += 2;
+      g->on_index_hole_ = p[at++] != 0;
+      g->write_protection_on_ = p[at++] != 0;
+      g->fixed_speed_ = p[at++] != 0;
+      g->read_ = p[at++] != 0;
+      g->sync_write_ = p[at++] != 0;
+      g->sync_found_ = p[at++] != 0;
+      g->byte_ready_ = p[at++] != 0;
+      g->data_bit_ = p[at++] != 0;
+      g->motor_on_ = p[at++] != 0;
+      g->new_bit_available_ = p[at++] != 0;
+
+      unsigned int bits;
+      bits = GetU32(&p[at]); at += 4; memcpy(&g->time_for_one_bit_, &bits, 4);
+      bits = GetU32(&p[at]); at += 4; memcpy(&g->timer_count_, &bits, 4);
+   }
+
+   return (at == size);
+}
+
+bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
+{
+   if (machine == nullptr) return false;
+
+   std::vector<unsigned char> sna;
+   if (!machine->SaveSnapshotNow(sna) || sna.empty())
+      return false;
+
+   out.clear();
+   out.insert(out.end(), kMagic, kMagic + 4);
+   PutU16(out, VERSION);
+   PutU16(out, 0);
+   PutU32(out, (unsigned int)sna.size());
+   out.insert(out.end(), sna.begin(), sna.end());
+
+   WriteScheduler(machine->GetMotherboard(), out);
+   WriteZ80(machine->GetMotherboard(), out);
+   WriteGateArray(machine->GetMotherboard(), out);
+   WritePsg(machine->GetMotherboard(), out);
+   WriteFdc(machine->GetMotherboard(), out);
+   WriteDrives(machine->GetMotherboard(), out);
+
+   return true;
+}
+
+bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, size_t size)
+{
+   if (machine == nullptr || buffer == nullptr) return false;
+   if (size < kHeaderSize) return false;
+   if (memcmp(buffer, kMagic, 4) != 0) return false;
+   if (GetU16(&buffer[4]) != VERSION) return false;
+
+   const unsigned int sna_size = GetU32(&buffer[8]);
+   if (sna_size == 0 || kHeaderSize + sna_size > size) return false;
+
+   // The .SNA goes in first: it resets and repopulates the components, so
+   // anything the chunks restore has to be applied after it.
+   if (!machine->LoadSnapshotNow(&buffer[kHeaderSize], sna_size))
+      return false;
+
+   size_t at = kHeaderSize + sna_size;
+   while (at + 8 <= size)
+   {
+      const unsigned int id = GetU32(&buffer[at]);
+      const unsigned int length = GetU32(&buffer[at + 4]);
+      at += 8;
+      if (at + length > size) return false;
+
+      if (id == kChunkScheduler)
+      {
+         if (!ReadScheduler(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkZ80)
+      {
+         if (!ReadZ80(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkGateArray)
+      {
+         if (!ReadGateArray(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkPsg)
+      {
+         if (!ReadPsg(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkFdc)
+      {
+         if (!ReadFdc(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkDrives)
+      {
+         if (!ReadDrives(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      // Unknown chunks are skipped, so a state from a newer build still loads.
+
+      at += length;
+   }
+
+   return true;
+}

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -1185,7 +1185,7 @@ bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out
 
    out.clear();
    out.insert(out.end(), kMagic, kMagic + 4);
-   PutU16(out, VERSION);
+   PutU16(out, kVersion);
    PutU16(out, 0);
    PutU32(out, (unsigned int)sna.size());
    out.insert(out.end(), sna.begin(), sna.end());
@@ -1210,7 +1210,7 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
    if (machine == nullptr || buffer == nullptr) return false;
    if (size < kHeaderSize) return false;
    if (memcmp(buffer, kMagic, 4) != 0) return false;
-   if (GetU16(&buffer[4]) != VERSION) return false;
+   if (GetU16(&buffer[4]) != kVersion) return false;
 
    const unsigned int sna_size = GetU32(&buffer[8]);
    if (sna_size == 0 || kHeaderSize + sna_size > size) return false;

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -8,6 +8,7 @@
 #include "PPI.h"
 #include "DMA.h"
 #include "PlayCity.h"
+#include "Memoire.h"
 
 #include <cstring>
 
@@ -95,6 +96,19 @@ const unsigned int kChunkDma = 0x444D4158;  // "DMAX"
 // with it enabled has to carry it or savestates break for everyone who turns it
 // on.
 const unsigned int kChunkPlayCity = 0x50434954;  // "PCIT"
+
+// Expansion RAM beyond the first 64 KB page.
+//
+// The .SNA writer records the dump size as 64 or 128 and emits at most the base
+// bank plus one expansion page, so a 576 KB machine -- SymbOS, OrgaMS, X-MEM,
+// the FutureOS 512 KB configurations -- silently loses 448 KB. Carrying the rest
+// here rather than widening the .SNA keeps the interchange format exactly as it
+// is: other emulators read what they always read, and none of the existing
+// snapshot tests change behaviour.
+//
+// Page 0 is deliberately absent: the .SNA already carries it, and writing it
+// twice would be a second source of truth.
+const unsigned int kChunkExtendedRam = 0x5852414D;  // "XRAM"
 
 
 void PutU16(std::vector<unsigned char>& out, unsigned short v)
@@ -1175,6 +1189,72 @@ bool MachineState::ReadPlayCity(Motherboard* board, const unsigned char* p, size
    return (at == size);
 }
 
+void MachineState::WriteExtendedRam(Motherboard* board, std::vector<unsigned char>& out)
+{
+   Memory* mem = board->GetMem();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkExtendedRam);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   // Which pages this machine has, so a state cannot be applied to a machine
+   // configured with less memory than it describes.
+   unsigned int available = 0;
+   for (int page = 0; page < 8; ++page)
+      if (mem->extended_ram_available_[page]) available |= (1u << page);
+   PutU32(out, available);
+
+   for (int page = 1; page < 8; ++page)
+   {
+      if (!mem->extended_ram_available_[page]) continue;
+      for (int bank = 0; bank < 4; ++bank)
+         out.insert(out.end(), mem->extended_ram_buffer_[page][bank],
+                               mem->extended_ram_buffer_[page][bank] + 0x4000);
+   }
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadExtendedRam(Motherboard* board, const unsigned char* p, size_t size)
+{
+   Memory* mem = board->GetMem();
+   if (size < 4) return false;
+
+   const unsigned int available = GetU32(&p[0]);
+   size_t at = 4;
+
+   unsigned int machine_available = 0;
+   for (int page = 0; page < 8; ++page)
+      if (mem->extended_ram_available_[page]) machine_available |= (1u << page);
+
+   // Refuse rather than half-fill a machine that has different memory: writing
+   // a 576 KB state into a 128 KB machine would drop 448 KB on the floor, and
+   // the reverse would leave stale pages behind.
+   if (available != machine_available) return false;
+
+   size_t expected = 4;
+   for (int page = 1; page < 8; ++page)
+      if (available & (1u << page)) expected += 4 * 0x4000;
+   if (size != expected) return false;
+
+   for (int page = 1; page < 8; ++page)
+   {
+      if (!(available & (1u << page))) continue;
+      for (int bank = 0; bank < 4; ++bank)
+      {
+         memcpy(mem->extended_ram_buffer_[page][bank], &p[at], 0x4000);
+         at += 0x4000;
+      }
+   }
+
+   return (at == size);
+}
+
 bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
 {
    if (machine == nullptr) return false;
@@ -1201,6 +1281,7 @@ bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out
    WritePpi(machine->GetMotherboard(), out);
    WriteDma(machine->GetMotherboard(), out);
    WritePlayCity(machine->GetMotherboard(), out);
+   WriteExtendedRam(machine->GetMotherboard(), out);
 
    return true;
 }
@@ -1281,6 +1362,11 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
       else if (id == kChunkPlayCity)
       {
          if (!ReadPlayCity(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkExtendedRam)
+      {
+         if (!ReadExtendedRam(machine->GetMotherboard(), &buffer[at], length))
             return false;
       }
       // Unknown chunks are skipped, so a state from a newer build still loads.

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -4,6 +4,7 @@
 #include "Motherboard.h"
 #include "DiskGen.h"
 #include "IDisk.h"
+#include "Tape.h"
 
 #include <cstring>
 
@@ -61,6 +62,15 @@ const unsigned int kChunkDrives = 0x44525653;  // "DRVS"
 // moment a state crosses into a process that did not.
 const unsigned int kChunkCrtc = 0x43525443;  // "CRTC"
 
+// The tape. The .SNA has nothing for it at all -- not even the equivalent of
+// the disk's motor flag and current track -- so everything here is new.
+//
+// Same split as the drives: the flux array is media and stays out, the position
+// within it is state, and the size of the array is recorded so that a state can
+// be refused rather than applied to a different tape.
+const unsigned int kChunkTape = 0x54415045;  // "TAPE"
+
+
 void PutU16(std::vector<unsigned char>& out, unsigned short v)
 {
    out.push_back(v & 0xFF);
@@ -81,6 +91,23 @@ unsigned int GetU32(const unsigned char* p)
 {
    return p[0] | (p[1] << 8) | (p[2] << 16) | ((unsigned int)p[3] << 24);
 }
+void PutF64(std::vector<unsigned char>& out, double v)
+{
+   unsigned long long bits;
+   memcpy(&bits, &v, 8);
+   PutU32(out, (unsigned int)(bits & 0xFFFFFFFFu));
+   PutU32(out, (unsigned int)(bits >> 32));
+}
+
+double GetF64(const unsigned char* p)
+{
+   const unsigned long long bits =
+      (unsigned long long)GetU32(p) | ((unsigned long long)GetU32(p + 4) << 32);
+   double v;
+   memcpy(&v, &bits, 8);
+   return v;
+}
+
 
 }  // namespace
 
@@ -804,6 +831,120 @@ bool MachineState::ReadCrtc(Motherboard* board, const unsigned char* p, size_t s
    return (at == size);
 }
 
+void MachineState::WriteTape(Motherboard* board, std::vector<unsigned char>& out)
+{
+   CTape* t = board->GetTape();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkTape);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   // Identity of the tape in the deck.
+   out.push_back(t->is_tape_inserted_ ? 1 : 0);
+   out.push_back(t->tape_array_ != nullptr ? 1 : 0);
+   PutU32(out, t->nb_inversions_);
+   PutU32(out, t->array_size_);
+   PutU32(out, t->nb_blocks_);
+
+   // Where it is.
+   PutU32(out, t->tape_position_);
+   PutU32(out, (unsigned int)(t->remaining_reversal_flux_ & 0xFFFFFFFFu));
+   PutU32(out, (unsigned int)(t->remaining_reversal_flux_ >> 32));
+   PutU32(out, (unsigned int)(t->counter_us_ & 0xFFFFFFFFu));
+   PutU32(out, (unsigned int)(t->counter_us_ >> 32));
+   PutU32(out, (unsigned int)t->counter_sec_);
+   PutU32(out, t->tape_length_);
+
+   out.push_back(t->motor_on_ ? 1 : 0);
+   out.push_back(t->previous_motor_on_ ? 1 : 0);
+   out.push_back(t->next_motor_state_ ? 1 : 0);
+   PutU32(out, (unsigned int)t->time_to_change_motor_state_);
+   out.push_back(t->play_ ? 1 : 0);
+   out.push_back(t->record_ ? 1 : 0);
+   out.push_back(t->start_record_ ? 1 : 0);
+   out.push_back(t->tape_changed_ ? 1 : 0);
+   out.push_back(t->pending_tape_ ? 1 : 0);
+   out.push_back(t->current_level_ ? 1 : 0);
+   out.push_back(t->polarity_inversion_ ? 1 : 0);
+
+   PutU32(out, (unsigned int)t->frequency_);
+   PutU16(out, t->pilot_pulse_);
+   PutU16(out, t->pilot_length_);
+   PutU16(out, t->zero_);
+   PutU16(out, t->one_);
+   PutU32(out, (unsigned int)t->current_block_type_);
+   PutU32(out, (unsigned int)t->current_block_);
+   PutU32(out, t->nb_samples_);
+   PutU32(out, (unsigned int)t->nb_sample_to_read_);
+   PutU32(out, (unsigned int)t->carry_);
+   PutU32(out, (unsigned int)t->oldcarry_);
+   PutF64(out, t->sample_rate_);
+   PutF64(out, t->last_time_);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadTape(Motherboard* board, const unsigned char* p, size_t size)
+{
+   CTape* t = board->GetTape();
+   size_t at = 0;
+   if (size < 100) return false;
+
+   const bool was_inserted = p[at++] != 0;
+   const bool had_flux = p[at++] != 0;
+   const unsigned int nb_inversions = GetU32(&p[at]); at += 4;
+   const unsigned int array_size = GetU32(&p[at]); at += 4;
+   const unsigned int nb_blocks = GetU32(&p[at]); at += 4;
+
+   // Refuse rather than seek into a tape that is not the one described.
+   if (was_inserted != t->is_tape_inserted_) return false;
+   if (had_flux != (t->tape_array_ != nullptr)) return false;
+   if (nb_inversions != t->nb_inversions_) return false;
+   if (array_size != t->array_size_) return false;
+   if (nb_blocks != t->nb_blocks_) return false;
+
+   t->tape_position_ = GetU32(&p[at]); at += 4;
+   t->remaining_reversal_flux_ =
+      (unsigned long long)GetU32(&p[at]) | ((unsigned long long)GetU32(&p[at+4]) << 32); at += 8;
+   t->counter_us_ =
+      (unsigned long long)GetU32(&p[at]) | ((unsigned long long)GetU32(&p[at+4]) << 32); at += 8;
+   t->counter_sec_ = (int)GetU32(&p[at]); at += 4;
+   t->tape_length_ = GetU32(&p[at]); at += 4;
+
+   t->motor_on_ = p[at++] != 0;
+   t->previous_motor_on_ = p[at++] != 0;
+   t->next_motor_state_ = p[at++] != 0;
+   t->time_to_change_motor_state_ = (int)GetU32(&p[at]); at += 4;
+   t->play_ = p[at++] != 0;
+   t->record_ = p[at++] != 0;
+   t->start_record_ = p[at++] != 0;
+   t->tape_changed_ = p[at++] != 0;
+   t->pending_tape_ = p[at++] != 0;
+   t->current_level_ = p[at++] != 0;
+   t->polarity_inversion_ = p[at++] != 0;
+
+   t->frequency_ = (int)GetU32(&p[at]); at += 4;
+   t->pilot_pulse_ = GetU16(&p[at]); at += 2;
+   t->pilot_length_ = GetU16(&p[at]); at += 2;
+   t->zero_ = GetU16(&p[at]); at += 2;
+   t->one_ = GetU16(&p[at]); at += 2;
+   t->current_block_type_ = (int)GetU32(&p[at]); at += 4;
+   t->current_block_ = (int)GetU32(&p[at]); at += 4;
+   t->nb_samples_ = GetU32(&p[at]); at += 4;
+   t->nb_sample_to_read_ = (int)GetU32(&p[at]); at += 4;
+   t->carry_ = (int)GetU32(&p[at]); at += 4;
+   t->oldcarry_ = (int)GetU32(&p[at]); at += 4;
+   t->sample_rate_ = GetF64(&p[at]); at += 8;
+   t->last_time_ = GetF64(&p[at]); at += 8;
+
+   return (at == size);
+}
+
 bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
 {
    if (machine == nullptr) return false;
@@ -826,6 +967,7 @@ bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out
    WriteFdc(machine->GetMotherboard(), out);
    WriteDrives(machine->GetMotherboard(), out);
    WriteCrtc(machine->GetMotherboard(), out);
+   WriteTape(machine->GetMotherboard(), out);
 
    return true;
 }
@@ -886,6 +1028,11 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
       else if (id == kChunkCrtc)
       {
          if (!ReadCrtc(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkTape)
+      {
+         if (!ReadTape(machine->GetMotherboard(), &buffer[at], length))
             return false;
       }
       // Unknown chunks are skipped, so a state from a newer build still loads.

--- a/CPCCoreEmu/MachineState.cpp
+++ b/CPCCoreEmu/MachineState.cpp
@@ -5,6 +5,7 @@
 #include "DiskGen.h"
 #include "IDisk.h"
 #include "Tape.h"
+#include "PPI.h"
 
 #include <cstring>
 
@@ -69,6 +70,15 @@ const unsigned int kChunkCrtc = 0x43525443;  // "CRTC"
 // within it is state, and the size of the array is recorded so that a state can
 // be refused rather than applied to a different tape.
 const unsigned int kChunkTape = 0x54415045;  // "TAPE"
+
+// The PPI's tape input level. The .SNA carries the three ports and the control
+// word, but not the signal the tape is presenting to port B, which is the bit
+// the firmware's loading loop samples. Leave it behind and a restored machine
+// reads the wrong bit at the wrong moment, and the loop takes a different path
+// while every other component stays in step -- as confusing to diagnose as it
+// sounds, and only visible when the state is loaded into a machine whose own
+// tape level happened to differ.
+const unsigned int kChunkPpi = 0x50504958;  // "PPIX"
 
 
 void PutU16(std::vector<unsigned char>& out, unsigned short v)
@@ -945,6 +955,34 @@ bool MachineState::ReadTape(Motherboard* board, const unsigned char* p, size_t s
    return (at == size);
 }
 
+void MachineState::WritePpi(Motherboard* board, std::vector<unsigned char>& out)
+{
+   PPI8255* ppi = board->GetPPI();
+
+   const size_t length_at = out.size() + 4;
+   PutU32(out, kChunkPpi);
+   PutU32(out, 0);
+   const size_t payload_at = out.size();
+
+   out.push_back(ppi->tape_level_);
+   out.push_back(ppi->tape_write_data_level_ ? 1 : 0);
+
+   const unsigned int payload_size = (unsigned int)(out.size() - payload_at);
+   out[length_at + 0] = payload_size & 0xFF;
+   out[length_at + 1] = (payload_size >> 8) & 0xFF;
+   out[length_at + 2] = (payload_size >> 16) & 0xFF;
+   out[length_at + 3] = (payload_size >> 24) & 0xFF;
+}
+
+bool MachineState::ReadPpi(Motherboard* board, const unsigned char* p, size_t size)
+{
+   PPI8255* ppi = board->GetPPI();
+   if (size != 2) return false;
+   ppi->tape_level_ = p[0];
+   ppi->tape_write_data_level_ = p[1] != 0;
+   return true;
+}
+
 bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out)
 {
    if (machine == nullptr) return false;
@@ -968,6 +1006,7 @@ bool MachineState::Save(EmulatorEngine* machine, std::vector<unsigned char>& out
    WriteDrives(machine->GetMotherboard(), out);
    WriteCrtc(machine->GetMotherboard(), out);
    WriteTape(machine->GetMotherboard(), out);
+   WritePpi(machine->GetMotherboard(), out);
 
    return true;
 }
@@ -1033,6 +1072,11 @@ bool MachineState::Load(EmulatorEngine* machine, const unsigned char* buffer, si
       else if (id == kChunkTape)
       {
          if (!ReadTape(machine->GetMotherboard(), &buffer[at], length))
+            return false;
+      }
+      else if (id == kChunkPpi)
+      {
+         if (!ReadPpi(machine->GetMotherboard(), &buffer[at], length))
             return false;
       }
       // Unknown chunks are skipped, so a state from a newer build still loads.

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -5,6 +5,7 @@
 
 class EmulatorEngine;
 class Motherboard;
+class YMZ294;
 
 // A save state for the whole engine, as opposed to a .SNA.
 //
@@ -58,4 +59,10 @@ private:
    static bool ReadTape(Motherboard* board, const unsigned char* p, size_t size);
    static void WritePpi(Motherboard* board, std::vector<unsigned char>& out);
    static bool ReadPpi(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteYmz(YMZ294* y, std::vector<unsigned char>& out);
+   static void ReadYmz(YMZ294* y, const unsigned char* p, size_t& at);
+   static void WriteDma(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadDma(Motherboard* board, const unsigned char* p, size_t size);
+   static void WritePlayCity(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadPlayCity(Motherboard* board, const unsigned char* p, size_t size);
 };

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -56,4 +56,6 @@ private:
    static bool ReadCrtc(Motherboard* board, const unsigned char* p, size_t size);
    static void WriteTape(Motherboard* board, std::vector<unsigned char>& out);
    static bool ReadTape(Motherboard* board, const unsigned char* p, size_t size);
+   static void WritePpi(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadPpi(Motherboard* board, const unsigned char* p, size_t size);
 };

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -52,4 +52,6 @@ private:
    static bool ReadFdc(Motherboard* board, const unsigned char* p, size_t size);
    static void WriteDrives(Motherboard* board, std::vector<unsigned char>& out);
    static bool ReadDrives(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteCrtc(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadCrtc(Motherboard* board, const unsigned char* p, size_t size);
 };

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -33,7 +33,11 @@ class MachineState
 public:
    // Bumped when a chunk's payload changes shape. Loading refuses a version it
    // does not know rather than misreading it.
-   static constexpr unsigned short VERSION = 1;
+   //
+   // Not named VERSION: that is a macro in the Windows SDK headers, which
+   // stdafx.h pulls in, and the expansion turns this line into a syntax error
+   // on MSVC only.
+   static constexpr unsigned short kVersion = 1;
 
    static bool Save(EmulatorEngine* machine, std::vector<unsigned char>& out);
    static bool Load(EmulatorEngine* machine, const unsigned char* buffer, size_t size);

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -71,4 +71,10 @@ private:
    static bool ReadPlayCity(Motherboard* board, const unsigned char* p, size_t size);
    static void WriteExtendedRam(Motherboard* board, std::vector<unsigned char>& out);
    static bool ReadExtendedRam(Motherboard* board, const unsigned char* p, size_t size);
+
+   // Everything a chunk checks about the machine it is being loaded into,
+   // verified before anything is written. See the comment on the definition.
+   static bool DescribesThisMachine(Motherboard* board,
+                                    const unsigned char* buffer, size_t size,
+                                    size_t first_chunk);
 };

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -33,7 +33,7 @@ class MachineState
 public:
    // Bumped when a chunk's payload changes shape. Loading refuses a version it
    // does not know rather than misreading it.
-   static const unsigned short VERSION = 1;
+   static constexpr unsigned short VERSION = 1;
 
    static bool Save(EmulatorEngine* machine, std::vector<unsigned char>& out);
    static bool Load(EmulatorEngine* machine, const unsigned char* buffer, size_t size);

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -54,4 +54,6 @@ private:
    static bool ReadDrives(Motherboard* board, const unsigned char* p, size_t size);
    static void WriteCrtc(Motherboard* board, std::vector<unsigned char>& out);
    static bool ReadCrtc(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteTape(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadTape(Motherboard* board, const unsigned char* p, size_t size);
 };

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <vector>
+#include <cstddef>
+
+class EmulatorEngine;
+class Motherboard;
+
+// A save state for the whole engine, as opposed to a .SNA.
+//
+// A .SNA is an interchange format: it describes the machine an Amstrad user
+// could see, and nothing else. That is not enough to resume emulation exactly
+// where it stopped -- the scheduler's per-component cycle debt, the CPU's
+// mid-instruction state and the tape and disk positions have no field in it,
+// at any version. A state saved here is ours: it may hold whatever the engine
+// needs, and it is never written to a file by this class, only to a buffer the
+// caller owns.
+//
+// Layout:
+//   "SBXS"        4 bytes
+//   version       2 bytes, little endian
+//   reserved      2 bytes
+//   sna length    4 bytes, little endian
+//   sna image     <sna length> bytes
+//   chunks        [4 byte id][4 byte length][payload], to the end of the buffer
+//
+// The .SNA image carries everything the container can express, so this class
+// only has to add what it cannot. Chunks are skipped when unknown, so a state
+// written by a newer build still loads what an older one understands.
+class MachineState
+{
+public:
+   // Bumped when a chunk's payload changes shape. Loading refuses a version it
+   // does not know rather than misreading it.
+   static const unsigned short VERSION = 1;
+
+   static bool Save(EmulatorEngine* machine, std::vector<unsigned char>& out);
+   static bool Load(EmulatorEngine* machine, const unsigned char* buffer, size_t size);
+
+private:
+   // Members rather than free functions: Motherboard grants friendship to this
+   // class, and friendship does not extend to anything outside it.
+   static void WriteScheduler(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadScheduler(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteZ80(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadZ80(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteGateArray(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadGateArray(Motherboard* board, const unsigned char* p, size_t size);
+   static void WritePsg(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadPsg(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteFdc(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadFdc(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteDrives(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadDrives(Motherboard* board, const unsigned char* p, size_t size);
+};

--- a/CPCCoreEmu/MachineState.h
+++ b/CPCCoreEmu/MachineState.h
@@ -69,4 +69,6 @@ private:
    static bool ReadDma(Motherboard* board, const unsigned char* p, size_t size);
    static void WritePlayCity(Motherboard* board, std::vector<unsigned char>& out);
    static bool ReadPlayCity(Motherboard* board, const unsigned char* p, size_t size);
+   static void WriteExtendedRam(Motherboard* board, std::vector<unsigned char>& out);
+   static bool ReadExtendedRam(Motherboard* board, const unsigned char* p, size_t size);
 };

--- a/CPCCoreEmu/Memoire.h
+++ b/CPCCoreEmu/Memoire.h
@@ -12,6 +12,8 @@ class Monitor;
 
 class Memory : public IDmaSTOP
 {
+   friend class MachineState;
+
    friend class EmulatorEngine;
    friend class CSnapshot;
 

--- a/CPCCoreEmu/Motherboard.h
+++ b/CPCCoreEmu/Motherboard.h
@@ -58,6 +58,10 @@ public:
 
 class Motherboard : public IMachine
 {
+   // Reads and restores the scheduler state, which is deliberately not part of
+   // the public surface: nothing outside a save state has any business with it.
+   friend class MachineState;
+
 public:
 
    ///////////////////////////////////////

--- a/CPCCoreEmu/PPI.h
+++ b/CPCCoreEmu/PPI.h
@@ -21,6 +21,8 @@ class CSnapshot;
 
 class CPCCOREEMU_API PPI8255 : public ITapeOut
 {
+   friend class MachineState;
+
 public:
    PPI8255( );
    virtual ~PPI8255();

--- a/CPCCoreEmu/PSG.h
+++ b/CPCCoreEmu/PSG.h
@@ -12,6 +12,7 @@ class Ay8912 : public IComponent
 {
 friend class EmulatorEngine;
 friend class CSnapshot;
+friend class MachineState;
 public:
    
    Ay8912(SoundMixer *sound_hub, IKeyboardHandler* keyboard_handler);

--- a/CPCCoreEmu/PlayCity.h
+++ b/CPCCoreEmu/PlayCity.h
@@ -13,6 +13,8 @@
 
 class PlayCity : public IExpansion
 {
+   friend class MachineState;
+
 public:
    PlayCity(IClockable* int_line, IClockable* nmi_line, /*SoundMixer *mixer, */SoundMixer *sound_hub);
    virtual ~PlayCity(void);

--- a/CPCCoreEmu/Tape.h
+++ b/CPCCoreEmu/Tape.h
@@ -81,6 +81,8 @@ private:
 
 class CTape : public IComponent, public IExternalSource, public ILoadingProgress
 {
+   friend class MachineState;
+
 public:
    CTape(void);
    virtual ~CTape(void);

--- a/CPCCoreEmu/YMZ294.h
+++ b/CPCCoreEmu/YMZ294.h
@@ -16,6 +16,8 @@ const int CLOCK_DIV = 0;
 
 class YMZ294 : public IClockable
 {
+   friend class MachineState;
+
 public:
    typedef enum {
       LEFT, 

--- a/CPCCoreEmu/Z84C30.h
+++ b/CPCCoreEmu/Z84C30.h
@@ -12,6 +12,8 @@
 
 class Z84C30 : public IClockable
 {
+   friend class MachineState;
+
 public:
 
    enum ChannelId
@@ -40,6 +42,8 @@ public:
 public:
    class CTCCounter : public IClockable
    {
+      friend class MachineState;
+
    public:
       enum ControlWord
       {

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable( unitTests
                      TestStateDeterminism.cpp
                      TestMachineState.cpp
                      TestMachineStateSize.cpp
+                     TestMachineStateExpansions.cpp
 
 )
 

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -55,6 +55,8 @@ add_executable( unitTests
                      TestZ84C30.cpp
                      TestSnapshot.cpp
                      TestSnapshotMachineType.cpp
+                     TestStateDeterminism.cpp
+                     TestMachineState.cpp
 
 )
 

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable( unitTests
                      TestSnapshotMachineType.cpp
                      TestStateDeterminism.cpp
                      TestMachineState.cpp
+                     TestMachineStateRam.cpp
                      TestMachineStateSize.cpp
                      TestMachineStateExpansions.cpp
 

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable( unitTests
                      TestSnapshotMachineType.cpp
                      TestStateDeterminism.cpp
                      TestMachineState.cpp
+                     TestMachineStateSize.cpp
 
 )
 

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -1,0 +1,342 @@
+#include "gtest/gtest.h"
+
+#include "TestUtils.h"
+#include "MachineState.h"
+
+#include <string>
+#include <vector>
+
+// Does a full engine state put the machine back where it was, well enough that
+// it then runs the same way?
+//
+// StateDeterminism asks that of a .SNA and answers no: every fingerprinted
+// field diverges once the machine runs on, because the scheduler's per-component
+// cycle debt has no field in the container. This asks the same question of
+// MachineState, which adds that debt on top of the .SNA, and asserts the answer
+// is yes.
+//
+// The two tests share their method deliberately. The .SNA one is the control:
+// if it ever stops diverging, this one has stopped proving anything.
+
+namespace
+{
+
+struct Fingerprint
+{
+   std::vector<std::pair<std::string, unsigned long long> > fields;
+
+   void Add(const char* name, unsigned long long value)
+   {
+      fields.push_back(std::make_pair(std::string(name), value));
+   }
+
+   void AddBlock(const char* name, const unsigned char* data, size_t size)
+   {
+      unsigned long long h = 14695981039346656037ULL;
+      for (size_t i = 0; i < size; ++i)
+      {
+         h ^= data[i];
+         h *= 1099511628211ULL;
+      }
+      Add(name, h);
+   }
+};
+
+Fingerprint Capture(EmulatorEngine* machine)
+{
+   Fingerprint f;
+
+   f.AddBlock("ram", machine->GetMem()->GetRamBuffer(), 0x10000);
+
+   Z80* z80 = machine->GetProc();
+   f.Add("z80.pc", z80->pc_);
+   f.Add("z80.sp", z80->sp_);
+   f.Add("z80.iff1", z80->iff1_ ? 1 : 0);
+   f.Add("z80.iff2", z80->iff2_ ? 1 : 0);
+   f.Add("z80.opcode", z80->current_opcode_);
+   f.Add("z80.machine_cycle", z80->machine_cycle_);
+   f.Add("z80.t", z80->t_);
+
+   CRTC* crtc = machine->GetCRTC();
+   f.Add("crtc.hcc", crtc->hcc_);
+   f.Add("crtc.vcc", crtc->vcc_);
+   f.Add("crtc.vlc", crtc->vlc_);
+   f.AddBlock("crtc.registers", crtc->registers_list_, sizeof(crtc->registers_list_));
+
+   CTape* tape = machine->GetTape();
+   f.Add("tape.position", tape->GetTapePosition());
+   f.Add("tape.inversions", tape->GetNbInversions());
+   f.Add("tape.recording", tape->IsRecordOn() ? 1 : 0);
+
+   f.Add("fdc.track0", machine->GetFDC()->GetCurrentTrack(0));
+   f.Add("fdc.motor", machine->GetFDC()->IsMotorOn() ? 1 : 0);
+   f.Add("fdc.main_status", machine->GetFDC()->GetMainStatus());
+
+   // Memory paging: which banks and which upper ROM the CPU currently sees.
+   f.Add("mem.selected_rom", machine->GetMem()->GetSelectedRom());
+   f.AddBlock("mem.bank0", machine->GetMem()->GetRamBuffer(), 0x4000);
+
+   // Gate array: what actually drives the interrupt the CPU will take next.
+   GateArray* ga = machine->GetVGA();
+   f.Add("ga.pen", ga->pen_r_);
+   f.Add("ga.screen_mode", ga->buffered_screen_mode_);
+
+   // PSG: the audible state, and the flag that selects keyboard vs latch on
+   // port A -- get that wrong and the firmware reads different keys.
+   Ay8912* psg = machine->GetPSG();
+   f.Add("psg.selected", psg->GetRegisterAdress());
+
+   return f;
+}
+
+EmulatorEngine* NewBootedMachine(DirectoriesImp& dirImp, CDisplay& display, Log& log,
+                                 SoundFactory& soundFactory, ConfigurationManager& conf_manager,
+                                 const char* section)
+{
+   EmulatorEngine* machine = new EmulatorEngine();
+
+   display.Init(false);
+   display.Show(false);
+
+   machine->SetDirectories(&dirImp);
+   machine->SetLog(&log);
+   machine->SetConfigurationManager(&conf_manager);
+   machine->Init(&display, &soundFactory);
+   machine->GetMem()->Initialisation();
+   machine->LoadConfiguration(section, "./TestConf.ini");
+   machine->Reinit();
+   machine->SetFixedSpeed(true);
+   machine->SetSpeedLimit(EmulatorEngine::E_FULL);
+
+   return machine;
+}
+
+}  // namespace
+
+namespace
+{
+
+// Long enough that a run which only looks identical cannot stay that way: the
+// firmware sweeps the keyboard, the gate array raises interrupts and the CRTC
+// completes frames many times over.
+const int kSlicesAfterSave = 400;
+
+void CheckOneMachine(const char* section, int slices_before_save,
+                    const char* disk = nullptr, const char* format = "")
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, section);
+
+   // With a disk inserted and the drive seeking, the FDC and the disk image
+   // carry state that an idle BASIC prompt never exercises.
+   if (disk != nullptr)
+   {
+      ASSERT_EQ(0, machine->LoadDisk(disk, 0, false))
+         << "the disk fixture did not load, so this case proves nothing: " << disk;
+
+      machine->Paste("cat\r");
+
+      // Run until the drive is actually turning and stop there. The motor spins
+      // down again once the access finishes, so waiting a fixed number of slices
+      // and then looking is a coin toss.
+      bool spinning = false;
+      for (int i = 0; i < 2000 && !spinning; ++i)
+      {
+         machine->RunTimeSlice(false);
+         spinning = machine->GetFDC()->IsMotorOn();
+      }
+      ASSERT_TRUE(spinning)
+         << "the drive never started, so the FDC state under test is still idle";
+   }
+
+   const int kSlicesBeforeSave = slices_before_save;
+
+   for (int i = 0; i < kSlicesBeforeSave; ++i)
+      machine->RunTimeSlice();
+
+   int ram_in_use = 0;
+   const unsigned char* ram = machine->GetMem()->GetRamBuffer();
+   for (int i = 0; i < 0x10000; ++i) if (ram[i] != 0) ++ram_in_use;
+   ASSERT_GT(ram_in_use, 0)
+      << "the machine never executed an instruction -- no ROMs found. This test "
+         "needs CONF/, ROM/ and res/ from UnitTests/ and Keyboards/ from "
+         "CPCCoreEmu/ reachable from the working directory.";
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+   ASSERT_FALSE(state.empty());
+   const Fingerprint at_save = Capture(machine);
+
+   for (int i = 0; i < kSlicesAfterSave; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint straight_through = Capture(machine);
+
+   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()));
+   const Fingerprint at_restore = Capture(machine);
+
+   // Split the two failure modes: a field that is already wrong the instant the
+   // state comes back was not carried, as opposed to one that only drifts once
+   // the machine runs on.
+   for (size_t i = 0; i < at_save.fields.size(); ++i)
+   {
+      if (at_save.fields[i].second != at_restore.fields[i].second)
+         fprintf(stderr, "  NOT CARRIED BY RESTORE: %s\n", at_save.fields[i].first.c_str());
+   }
+
+   for (int i = 0; i < kSlicesAfterSave; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint after_restore = Capture(machine);
+
+   delete machine;
+
+   ASSERT_EQ(straight_through.fields.size(), after_restore.fields.size());
+
+   int divergent = 0;
+   for (size_t i = 0; i < straight_through.fields.size(); ++i)
+   {
+      if (straight_through.fields[i].second == after_restore.fields[i].second)
+         continue;
+      ++divergent;
+      fprintf(stderr, "  STILL DIVERGES: %s\n", straight_through.fields[i].first.c_str());
+   }
+
+   fprintf(stderr, "MACHINE STATE %-9s save@%-5d %-6s %d of %zu fields diverged\n",
+      section, slices_before_save, disk ? format : "idle",
+      divergent, straight_through.fields.size());
+
+   EXPECT_EQ(0, divergent)
+      << section << " save@" << slices_before_save
+      << ": the state did not carry everything the machine needs to resume";
+}
+
+}  // namespace
+
+TEST(MachineStateTest, RestoringAStateReproducesTheSameRun)
+{
+   const char* sections[] = { "6128", "464", "6128PLUS" };
+   const int save_points[] = { 20, 137, 400 };
+
+   for (size_t s = 0; s < sizeof(sections) / sizeof(sections[0]); ++s)
+      for (size_t p = 0; p < sizeof(save_points) / sizeof(save_points[0]); ++p)
+         CheckOneMachine(sections[s], save_points[p]);
+}
+
+// The FDC and the disk only carry state worth restoring while the drive is
+// actually turning, which a BASIC prompt never makes happen.
+//
+// Once per container format, because they do not decode alike: a plain DSK has
+// one fixed-size image of each track, an EDSK varies the size per track, and
+// IPF, HFE and SCP describe the flux itself and can hold several revolutions of
+// the same track. The head position that has to survive a round trip means
+// something different in each.
+TEST(MachineStateTest, RestoringAStateReproducesTheSameRunWithADiskSpinning)
+{
+   struct Image { const char* path; const char* format; };
+   const Image images[] = {
+      { "./res/FDC/fdctest.dsk",                                            "DSK"  },
+      { "./res/DSK/Ace Of Aces (UK) (1985) [Original] (Weak Sectors).dsk",  "EDSK" },
+      { "./res/After Burner (UK) (1988) [Activision SEGA] (Pre-release).ipf","IPF"  },
+      { "./res/30YMD double sides 1 and 2.hfe",                             "HFE"  },
+      { "./res/The Demo [A].scp",                                           "SCP"  },
+   };
+
+   for (size_t i = 0; i < sizeof(images) / sizeof(images[0]); ++i)
+   {
+      SCOPED_TRACE(images[i].format);
+      CheckOneMachine("6128", 20, images[i].path, images[i].format);
+      CheckOneMachine("6128", 137, images[i].path, images[i].format);
+   }
+}
+
+TEST(MachineStateTest, RejectsSomethingThatIsNotAState)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   for (int i = 0; i < 20; ++i)
+      machine->RunTimeSlice();
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+
+   std::vector<unsigned char> bad = state;
+   bad[0] = 'X';
+   EXPECT_FALSE(MachineState::Load(machine, &bad[0], bad.size()))
+      << "a buffer without the magic must be refused";
+
+   bad = state;
+   bad[4] = 0xFE; bad[5] = 0xFF;
+   EXPECT_FALSE(MachineState::Load(machine, &bad[0], bad.size()))
+      << "an unknown version must be refused rather than misread";
+
+   EXPECT_FALSE(MachineState::Load(machine, &state[0], state.size() / 2))
+      << "a truncated state must be refused";
+
+   // A whole .SNA is not a MachineState, however valid it is on its own.
+   std::vector<unsigned char> sna;
+   ASSERT_TRUE(machine->SaveSnapshotNow(sna));
+   EXPECT_FALSE(MachineState::Load(machine, &sna[0], sna.size()));
+
+   delete machine;
+}
+
+// The other half of keeping media out of the state: a head position only means
+// something against the disk it was recorded on. Swap the disk and the state
+// must be refused, not applied to whatever happens to be in the drive.
+TEST(MachineStateTest, RefusesAStateTakenWithADifferentDisk)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   ASSERT_EQ(0, machine->LoadDisk("./res/FDC/fdctest.dsk", 0, false));
+   for (int i = 0; i < 100; ++i)
+      machine->RunTimeSlice(false);
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+
+   // Same drive, different geometry.
+   ASSERT_EQ(0, machine->LoadDisk(
+      "./res/After Burner (UK) (1988) [Activision SEGA] (Pre-release).ipf", 0, false));
+
+   const bool loaded = MachineState::Load(machine, &state[0], state.size());
+
+   const unsigned int tracks_now =
+      machine->GetFDC()->GetCurrentTrack(0) >= 0 ? 1u : 0u;
+   (void)tracks_now;
+
+   delete machine;
+
+   EXPECT_FALSE(loaded)
+      << "a state recorded against another disk was applied instead of refused";
+}
+
+// An empty drive is a geometry too: a state taken with no disk must not be
+// loaded into a machine that now has one.
+TEST(MachineStateTest, RefusesAStateTakenWithNoDiskWhenOneIsInserted)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   for (int i = 0; i < 100; ++i)
+      machine->RunTimeSlice(false);
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+
+   ASSERT_EQ(0, machine->LoadDisk("./res/FDC/fdctest.dsk", 0, false));
+
+   const bool loaded = MachineState::Load(machine, &state[0], state.size());
+   delete machine;
+
+   EXPECT_FALSE(loaded)
+      << "a state taken with an empty drive was applied to a loaded one";
+}

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -3,6 +3,8 @@
 #include "TestUtils.h"
 #include "MachineState.h"
 
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -339,4 +341,242 @@ TEST(MachineStateTest, RefusesAStateTakenWithNoDiskWhenOneIsInserted)
 
    EXPECT_FALSE(loaded)
       << "a state taken with an empty drive was applied to a loaded one";
+}
+
+// Every test above restores into the machine that saved, so a chunk holding a
+// raw pointer would still work: the object it points at is exactly where it was.
+// A savestate has to survive being loaded into a machine built from scratch,
+// whose components sit at different addresses. This is the cheap half of that
+// (same process, fresh instance); the expensive half is another process
+// entirely, which only differs by also reshuffling the address space.
+TEST(MachineStateTest, LoadsIntoAMachineThatDidNotSaveIt)
+{
+   const int kSlicesAfter = 400;
+
+   std::vector<unsigned char> state;
+   Fingerprint expected;
+
+   {
+      DirectoriesImp dirImp; CDisplay display; Log log;
+      SoundFactory soundFactory; ConfigurationManager conf_manager;
+      EmulatorEngine* saver =
+         NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+      for (int i = 0; i < 137; ++i)
+         saver->RunTimeSlice();
+
+      ASSERT_TRUE(MachineState::Save(saver, state));
+
+      for (int i = 0; i < kSlicesAfter; ++i)
+         saver->RunTimeSlice();
+      expected = Capture(saver);
+
+      delete saver;
+   }
+
+   // A second machine, deliberately run a different distance so that nothing it
+   // already holds could make the comparison pass by accident.
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* loader =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   for (int i = 0; i < 61; ++i)
+      loader->RunTimeSlice();
+
+   const Fingerprint before_load = Capture(loader);
+   ASSERT_TRUE(MachineState::Load(loader, &state[0], state.size()));
+
+   for (int i = 0; i < kSlicesAfter; ++i)
+      loader->RunTimeSlice();
+   const Fingerprint actual = Capture(loader);
+
+   delete loader;
+
+   ASSERT_EQ(expected.fields.size(), actual.fields.size());
+
+   bool differed_before = false;
+   for (size_t i = 0; i < before_load.fields.size(); ++i)
+      if (before_load.fields[i].second != expected.fields[i].second)
+         differed_before = true;
+   ASSERT_TRUE(differed_before)
+      << "the second machine already matched before loading, so this proves nothing";
+
+   int divergent = 0;
+   for (size_t i = 0; i < expected.fields.size(); ++i)
+   {
+      if (expected.fields[i].second == actual.fields[i].second) continue;
+      ++divergent;
+      fprintf(stderr, "  DIFFERS IN A FRESH MACHINE: %s\n", expected.fields[i].first.c_str());
+   }
+   fprintf(stderr, "CROSS INSTANCE: %d of %zu fields diverged\n",
+      divergent, expected.fields.size());
+
+   EXPECT_EQ(0, divergent)
+      << "the state depends on the machine instance that wrote it";
+}
+
+// ---------------------------------------------------------------------------
+// A state has to survive the process that wrote it.
+//
+// Everything above runs in one process, where a chunk that accidentally held a
+// host address would still work: the address is still valid. A savestate is
+// written, the emulator is closed, and the file is opened again days later in a
+// process whose heap and code sit somewhere else entirely. That is the case
+// that matters, and the only way to test it is to actually be a second process.
+//
+// So the test re-runs this binary. The child is the disabled test below, told
+// where to write by an argument the parent adds; it saves a state and the
+// fingerprint of the run that follows it. The parent then loads that state cold
+// and checks it reaches the same fingerprint.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+const char kStateOutFlag[] = "--machine-state-out=";
+
+std::string ArgumentValue(const char* prefix)
+{
+   const std::vector<std::string> argv = testing::internal::GetArgvs();
+   const size_t n = strlen(prefix);
+   for (size_t i = 0; i < argv.size(); ++i)
+      if (argv[i].compare(0, n, prefix) == 0)
+         return argv[i].substr(n);
+   return std::string();
+}
+
+bool WriteWholeFile(const std::string& path, const std::vector<unsigned char>& data)
+{
+   FILE* f = fopen(path.c_str(), "wb");
+   if (f == nullptr) return false;
+   const bool ok = data.empty() || fwrite(&data[0], 1, data.size(), f) == data.size();
+   fclose(f);
+   return ok;
+}
+
+bool ReadWholeFile(const std::string& path, std::vector<unsigned char>& data)
+{
+   FILE* f = fopen(path.c_str(), "rb");
+   if (f == nullptr) return false;
+   fseek(f, 0, SEEK_END);
+   const long size = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   bool ok = size > 0;
+   if (ok)
+   {
+      data.resize((size_t)size);
+      ok = fread(&data[0], 1, (size_t)size, f) == (size_t)size;
+   }
+   fclose(f);
+   return ok;
+}
+
+void WriteFingerprint(const std::string& path, const Fingerprint& f)
+{
+   FILE* out = fopen(path.c_str(), "wb");
+   ASSERT_NE(nullptr, out);
+   for (size_t i = 0; i < f.fields.size(); ++i)
+      fprintf(out, "%s %llu\n", f.fields[i].first.c_str(),
+              (unsigned long long)f.fields[i].second);
+   fclose(out);
+}
+
+// The distances the two processes agree on. Kept here so the child and the
+// parent cannot drift apart.
+const int kCrossProcessSlicesBeforeSave = 137;
+const int kCrossProcessSlicesAfterSave = 400;
+
+}  // namespace
+
+// Runs only in the child, which the parent starts with the output path appended.
+TEST(MachineStateTest, DISABLED_CrossProcessProducer)
+{
+   const std::string state_path = ArgumentValue(kStateOutFlag);
+   ASSERT_FALSE(state_path.empty())
+      << "this test is the child half of CrossProcess and is not meant to be run "
+         "on its own";
+
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   for (int i = 0; i < kCrossProcessSlicesBeforeSave; ++i)
+      machine->RunTimeSlice();
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+   ASSERT_TRUE(WriteWholeFile(state_path, state));
+
+   for (int i = 0; i < kCrossProcessSlicesAfterSave; ++i)
+      machine->RunTimeSlice();
+   WriteFingerprint(state_path + ".fingerprint", Capture(machine));
+
+   delete machine;
+}
+
+TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
+{
+   const std::vector<std::string> argv = testing::internal::GetArgvs();
+   ASSERT_FALSE(argv.empty());
+
+   const std::string state_path = testing::TempDir() + "cpccore_cross_process.state";
+   const std::string fingerprint_path = state_path + ".fingerprint";
+   remove(state_path.c_str());
+   remove(fingerprint_path.c_str());
+
+   std::string command = "\"" + argv[0] + "\""
+      + " --gtest_also_run_disabled_tests"
+      + " --gtest_filter=MachineStateTest.DISABLED_CrossProcessProducer"
+      + " " + kStateOutFlag + "\"" + state_path + "\"";
+   ASSERT_EQ(0, system(command.c_str()))
+      << "the child process failed; command was: " << command;
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(ReadWholeFile(state_path, state))
+      << "the child wrote no state at " << state_path;
+
+   FILE* fp = fopen(fingerprint_path.c_str(), "rb");
+   ASSERT_NE(nullptr, fp);
+   std::vector<std::pair<std::string, unsigned long long> > expected;
+   char name[128];
+   unsigned long long value;
+   while (fscanf(fp, "%127s %llu", name, &value) == 2)
+      expected.push_back(std::make_pair(std::string(name), value));
+   fclose(fp);
+   ASSERT_FALSE(expected.empty());
+
+   // Cold load, in this process, into a machine that has never seen that state.
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()))
+      << "a state written by another process was refused";
+
+   for (int i = 0; i < kCrossProcessSlicesAfterSave; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint actual = Capture(machine);
+
+   delete machine;
+   remove(state_path.c_str());
+   remove(fingerprint_path.c_str());
+
+   ASSERT_EQ(expected.size(), actual.fields.size());
+
+   int divergent = 0;
+   for (size_t i = 0; i < expected.size(); ++i)
+   {
+      ASSERT_EQ(expected[i].first, actual.fields[i].first);
+      if (expected[i].second == actual.fields[i].second) continue;
+      ++divergent;
+      fprintf(stderr, "  DIFFERS ACROSS PROCESSES: %s\n", expected[i].first.c_str());
+   }
+   fprintf(stderr, "CROSS PROCESS: %d of %zu fields diverged\n",
+      divergent, expected.size());
+
+   EXPECT_EQ(0, divergent)
+      << "the state did not survive being written by another process";
 }

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -636,12 +636,10 @@ TEST(MachineStateTest, RestoringAStateReproducesTheSameRunWithATapeRunning)
       "./res/Basil The Great Mouse Detective (UK) (1987) [Original] [TAPE].cdt";
    CheckOneMachine("464", 20, nullptr, "", kTape);
 
-   // Known residual, measured rather than assumed. Saving in the middle of a
-   // tape transfer leaves the CPU a few cycles from where it was: the raw object
-   // diff after four hundred slices shows the two runs identical everywhere --
-   // tape position, CRTC, PSG, FDC, RAM -- except the Z80's own registers, which
-   // are the loop counters of the firmware's tape-reading loop. Nothing is
-   // missing from the state; the restart point inside an instruction is not yet
-   // exact. Lower this when it is; it must never need raising.
-   CheckOneMachine("464", 137, nullptr, "", kTape, 3);
+   // Saving in the middle of a transfer used to leave three fields apart. The
+   // cause was the PPI's tape input level: the bit the firmware's loading loop
+   // samples, which the .SNA has no field for, so a restored machine read the
+   // wrong bit at the wrong moment and the loop took a different path while
+   // every other component stayed in step.
+   CheckOneMachine("464", 137, nullptr, "", kTape);
 }

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -615,16 +615,48 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
    EmulatorEngine* machine =
       NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
 
-   // If this ever refuses, the message has to say enough to tell a real
-   // incompatibility from a stale file: it failed once during development and
-   // the bare assertion said nothing useful.
+   // This refused once during development and was never reproduced, in over a
+   // hundred targeted runs. Rather than guess at a fix, describe the state fully
+   // when it happens: header, and every chunk with its length, so the next
+   // occurrence names the culprit instead of restarting the investigation.
    ASSERT_GE(state.size(), 12u);
-   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()))
-      << "a state written by another process was refused. " << state.size()
-      << " bytes, magic " << state[0] << state[1] << state[2] << state[3]
-      << ", version " << (state[4] | (state[5] << 8))
-      << " (this build writes " << MachineState::kVersion << ")"
-      << ", from " << state_path;
+   if (!MachineState::Load(machine, &state[0], state.size()))
+   {
+      std::string report;
+      char line[256];
+      snprintf(line, sizeof(line), "%zu bytes, magic %c%c%c%c, version %u (build writes %u)",
+               state.size(), state[0], state[1], state[2], state[3],
+               (unsigned)(state[4] | (state[5] << 8)), (unsigned)MachineState::kVersion);
+      report = line;
+
+      const unsigned int sna_len = state[8] | (state[9] << 8)
+                                 | (state[10] << 16) | ((unsigned int)state[11] << 24);
+      snprintf(line, sizeof(line), "\n  .SNA %u bytes", sna_len);
+      report += line;
+
+      size_t at = 12 + sna_len;
+      while (at + 8 <= state.size())
+      {
+         const unsigned int id = state[at] | (state[at+1] << 8)
+                               | (state[at+2] << 16) | ((unsigned int)state[at+3] << 24);
+         const unsigned int len = state[at+4] | (state[at+5] << 8)
+                                | (state[at+6] << 16) | ((unsigned int)state[at+7] << 24);
+         snprintf(line, sizeof(line), "\n  chunk %c%c%c%c %u bytes",
+                  (char)((id >> 24) & 0xFF), (char)((id >> 16) & 0xFF),
+                  (char)((id >> 8) & 0xFF), (char)(id & 0xFF), len);
+         report += line;
+         at += 8 + len;
+      }
+      if (at != state.size())
+      {
+         snprintf(line, sizeof(line), "\n  TRAILING: chunk walk ended at %zu of %zu",
+                  at, state.size());
+         report += line;
+      }
+
+      FAIL() << "a state written by another process was refused.\n  " << report
+             << "\n  from " << state_path;
+   }
 
    for (int i = 0; i < kCrossProcessSlicesAfterSave; ++i)
       machine->RunTimeSlice();

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -559,6 +559,14 @@ TEST(MachineStateTest, DISABLED_CrossProcessProducer)
    for (int i = 0; i < kCrossProcessSlicesBeforeSave; ++i)
       machine->RunTimeSlice();
 
+   // Assert in the child, where the message is unambiguous: a state written by a
+   // machine that never executed would load fine in the parent and fail the
+   // comparison for a reason that has nothing to do with the state format.
+   int ram_in_use = 0;
+   const unsigned char* ram = machine->GetMem()->GetRamBuffer();
+   for (int i = 0; i < 0x10000; ++i) if (ram[i] != 0) ++ram_in_use;
+   ASSERT_GT(ram_in_use, 0) << "the child machine never executed; no ROMs found";
+
    std::vector<unsigned char> state;
    ASSERT_TRUE(MachineState::Save(machine, state));
    ASSERT_TRUE(WriteWholeFile(state_path, state));
@@ -615,7 +623,7 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
       << "a state written by another process was refused. " << state.size()
       << " bytes, magic " << state[0] << state[1] << state[2] << state[3]
       << ", version " << (state[4] | (state[5] << 8))
-      << " (this build writes " << MachineState::VERSION << ")"
+      << " (this build writes " << MachineState::kVersion << ")"
       << ", from " << state_path;
 
    for (int i = 0; i < kCrossProcessSlicesAfterSave; ++i)

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -623,6 +623,16 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
       + " --gtest_also_run_disabled_tests"
       + " --gtest_filter=MachineStateTest.DISABLED_CrossProcessProducer"
       + " " + kStateOutFlag + "\"" + state_path + "\"";
+#ifdef _WIN32
+   // cmd.exe drops the outer pair of quotes from a command line that begins
+   // with one, which mangles a line that has more than one quoted part -- here
+   // the executable and the output path. Wrapping the whole thing in another
+   // pair is the documented way round it. Without this the child never runs and
+   // system() reports "The filename, directory name, or volume label syntax is
+   // incorrect", which looks exactly like an intermittent failure because it
+   // only happens on Windows.
+   command = "\"" + command + "\"";
+#endif
    ASSERT_EQ(0, system(command.c_str()))
       << "the child process failed; command was: " << command;
 

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -607,8 +607,16 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
    EmulatorEngine* machine =
       NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "6128");
 
+   // If this ever refuses, the message has to say enough to tell a real
+   // incompatibility from a stale file: it failed once during development and
+   // the bare assertion said nothing useful.
+   ASSERT_GE(state.size(), 12u);
    ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()))
-      << "a state written by another process was refused";
+      << "a state written by another process was refused. " << state.size()
+      << " bytes, magic " << state[0] << state[1] << state[2] << state[3]
+      << ", version " << (state[4] | (state[5] << 8))
+      << " (this build writes " << MachineState::VERSION << ")"
+      << ", from " << state_path;
 
    for (int i = 0; i < kCrossProcessSlicesAfterSave; ++i)
       machine->RunTimeSlice();

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -5,6 +5,12 @@
 
 #include <cstdio>
 #include <cstdlib>
+#ifndef _WIN32
+#include <unistd.h>
+#else
+#include <process.h>
+#define getpid _getpid
+#endif
 #include <string>
 #include <vector>
 
@@ -530,6 +536,9 @@ void WriteFingerprint(const std::string& path, const Fingerprint& f)
 {
    FILE* out = fopen(path.c_str(), "wb");
    ASSERT_NE(nullptr, out);
+   // First line identifies the writer, so the parent can tell its own child's
+   // output from a file left by some other test process.
+   fprintf(out, "pid %ld\n", (long)getpid());
    for (size_t i = 0; i < f.fields.size(); ++i)
       fprintf(out, "%s %llu\n", f.fields[i].first.c_str(),
               (unsigned long long)f.fields[i].second);
@@ -583,7 +592,13 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
    const std::vector<std::string> argv = testing::internal::GetArgvs();
    ASSERT_FALSE(argv.empty());
 
-   const std::string state_path = testing::TempDir() + "cpccore_cross_process.state";
+   // Per-process path. A fixed name in the temp directory is shared by every
+   // test process on the machine, so two runs at once -- ctest -j, or simply two
+   // shells -- would overwrite each other's state between the child writing it
+   // and the parent reading it.
+   char unique[64];
+   snprintf(unique, sizeof(unique), "cpccore_cross_process_%ld.state", (long)getpid());
+   const std::string state_path = testing::TempDir() + unique;
    const std::string fingerprint_path = state_path + ".fingerprint";
    remove(state_path.c_str());
    remove(fingerprint_path.c_str());
@@ -604,10 +619,16 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
    std::vector<std::pair<std::string, unsigned long long> > expected;
    char name[128];
    unsigned long long value;
+   long writer_pid = 0;
+   if (fscanf(fp, "pid %ld\n", &writer_pid) != 1)
+      writer_pid = 0;
    while (fscanf(fp, "%127s %llu", name, &value) == 2)
       expected.push_back(std::make_pair(std::string(name), value));
    fclose(fp);
    ASSERT_FALSE(expected.empty());
+   ASSERT_NE(0, writer_pid)
+      << "the fingerprint carries no writer id, so it cannot be attributed to "
+         "this test's own child";
 
    // Cold load, in this process, into a machine that has never seen that state.
    DirectoriesImp dirImp; CDisplay display; Log log;

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -118,18 +118,58 @@ EmulatorEngine* NewBootedMachine(DirectoriesImp& dirImp, CDisplay& display, Log&
 namespace
 {
 
+// Paste() queues keystrokes on EmulatorEngine, outside the machine, so a save
+// state neither does nor should carry them. Anything still queued when the state
+// is taken would be typed into the straight-through run and not into the
+// restored one, which looks exactly like a state that failed to carry something.
+void DrainTypist(EmulatorEngine* machine)
+{
+   for (int i = 0; i < 2000 && !machine->PasteBufferIsEmpty(); ++i)
+      machine->RunTimeSlice(false);
+   ASSERT_TRUE(machine->PasteBufferIsEmpty())
+      << "keystrokes were still queued, so the two runs would not see the same input";
+}
+
 // Long enough that a run which only looks identical cannot stay that way: the
 // firmware sweeps the keyboard, the gate array raises interrupts and the CRTC
 // completes frames many times over.
 const int kSlicesAfterSave = 400;
 
 void CheckOneMachine(const char* section, int slices_before_save,
-                    const char* disk = nullptr, const char* format = "")
+                    const char* disk = nullptr, const char* format = "",
+                    const char* tape = nullptr, int tolerated = 0)
 {
    DirectoriesImp dirImp; CDisplay display; Log log;
    SoundFactory soundFactory; ConfigurationManager conf_manager;
    EmulatorEngine* machine =
       NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, section);
+
+   // A tape only carries state worth restoring while it is running past the
+   // head. Inserted and stopped, it is as inert as an empty drive.
+   if (tape != nullptr)
+   {
+      ASSERT_EQ(0, machine->LoadTape(tape))
+         << "the tape fixture did not load, so this case proves nothing: " << tape;
+
+      // The sequence the tape dump tests use: the firmware, not the test, is
+      // what starts the motor.
+      for (int i = 0; i < 100; ++i)
+         machine->RunTimeSlice();
+      machine->Paste("RUN\"\r");
+      for (int i = 0; i < 20; ++i)
+         machine->RunTimeSlice(false);
+      machine->Paste(" ");
+
+      unsigned int position = 0;
+      for (int i = 0; i < 3000 && position == 0; ++i)
+      {
+         machine->RunTimeSlice(false);
+         position = machine->GetTape()->GetTapePosition();
+      }
+      ASSERT_GT(position, 0u)
+         << "the tape never advanced past the head, so this case is still idle";
+      DrainTypist(machine);
+   }
 
    // With a disk inserted and the drive seeking, the FDC and the disk image
    // carry state that an idle BASIC prompt never exercises.
@@ -151,6 +191,7 @@ void CheckOneMachine(const char* section, int slices_before_save,
       }
       ASSERT_TRUE(spinning)
          << "the drive never started, so the FDC state under test is still idle";
+      DrainTypist(machine);
    }
 
    const int kSlicesBeforeSave = slices_before_save;
@@ -171,12 +212,18 @@ void CheckOneMachine(const char* section, int slices_before_save,
    ASSERT_FALSE(state.empty());
    const Fingerprint at_save = Capture(machine);
 
+   // rand() is global to the process, not part of the machine, and the disk
+   // layer uses it for weak sectors and drive-speed jitter. Both runs have to
+   // start from the same point or they diverge for a reason no save state could
+   // ever fix.
+   srand(0x5AFE5EED);
    for (int i = 0; i < kSlicesAfterSave; ++i)
       machine->RunTimeSlice();
    const Fingerprint straight_through = Capture(machine);
 
    ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()));
    const Fingerprint at_restore = Capture(machine);
+   srand(0x5AFE5EED);
 
    // Split the two failure modes: a field that is already wrong the instant the
    // state comes back was not carried, as opposed to one that only drifts once
@@ -205,10 +252,10 @@ void CheckOneMachine(const char* section, int slices_before_save,
    }
 
    fprintf(stderr, "MACHINE STATE %-9s save@%-5d %-6s %d of %zu fields diverged\n",
-      section, slices_before_save, disk ? format : "idle",
+      section, slices_before_save, disk ? format : (tape ? "tape" : "idle"),
       divergent, straight_through.fields.size());
 
-   EXPECT_EQ(0, divergent)
+   EXPECT_LE(divergent, tolerated)
       << section << " save@" << slices_before_save
       << ": the state did not carry everything the machine needs to resume";
 }
@@ -579,4 +626,22 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
 
    EXPECT_EQ(0, divergent)
       << "the state did not survive being written by another process";
+}
+
+// The tape is the other moving medium, and the one the .SNA has nothing at all
+// for -- not even the equivalent of the FDC's motor flag and current track.
+TEST(MachineStateTest, RestoringAStateReproducesTheSameRunWithATapeRunning)
+{
+   const char* kTape =
+      "./res/Basil The Great Mouse Detective (UK) (1987) [Original] [TAPE].cdt";
+   CheckOneMachine("464", 20, nullptr, "", kTape);
+
+   // Known residual, measured rather than assumed. Saving in the middle of a
+   // tape transfer leaves the CPU a few cycles from where it was: the raw object
+   // diff after four hundred slices shows the two runs identical everywhere --
+   // tape position, CRTC, PSG, FDC, RAM -- except the Z80's own registers, which
+   // are the loop counters of the firmware's tape-reading loop. Nothing is
+   // missing from the state; the restart point inside an instruction is not yet
+   // exact. Lower this when it is; it must never need raising.
+   CheckOneMachine("464", 137, nullptr, "", kTape, 3);
 }

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -137,7 +137,8 @@ const int kSlicesAfterSave = 400;
 
 void CheckOneMachine(const char* section, int slices_before_save,
                     const char* disk = nullptr, const char* format = "",
-                    const char* tape = nullptr, int tolerated = 0)
+                    const char* tape = nullptr, int tolerated = 0,
+                    const char* run_command = nullptr)
 {
    DirectoriesImp dirImp; CDisplay display; Log log;
    SoundFactory soundFactory; ConfigurationManager conf_manager;
@@ -178,7 +179,7 @@ void CheckOneMachine(const char* section, int slices_before_save,
       ASSERT_EQ(0, machine->LoadDisk(disk, 0, false))
          << "the disk fixture did not load, so this case proves nothing: " << disk;
 
-      machine->Paste("cat\r");
+      machine->Paste(run_command != nullptr ? run_command : "cat\r");
 
       // Run until the drive is actually turning and stop there. The motor spins
       // down again once the access finishes, so waiting a fixed number of slices
@@ -192,6 +193,12 @@ void CheckOneMachine(const char* section, int slices_before_save,
       ASSERT_TRUE(spinning)
          << "the drive never started, so the FDC state under test is still idle";
       DrainTypist(machine);
+
+      // A loaded program needs time to start doing whatever it does; CAT does
+      // not, which is why the plain disk cases stop at the motor.
+      if (run_command != nullptr)
+         for (int i = 0; i < 600; ++i)
+            machine->RunTimeSlice(false);
    }
 
    const int kSlicesBeforeSave = slices_before_save;
@@ -642,4 +649,90 @@ TEST(MachineStateTest, RestoringAStateReproducesTheSameRunWithATapeRunning)
    // wrong bit at the wrong moment and the loop took a different path while
    // every other component stayed in step.
    CheckOneMachine("464", 137, nullptr, "", kTape);
+}
+
+// A Plus doing Plus things.
+//
+// Every other Plus case here sits at a BASIC prompt, where the ASIC, its three
+// DMA channels and the sprite hardware are all idle -- and a component that does
+// nothing during a test reads as perfectly carried whether it is or not. That
+// mistake has been made four times in this file's history. These run the ASIC
+// test programs off the disk the Plus.* tests use.
+TEST(MachineStateTest, RestoringAStateReproducesTheSameRunOnAPlusUsingTheAsic)
+{
+   const char* kAsicDisk = "./res/plus/asic.dsk";
+
+   struct Program { const char* command; const char* what; };
+   const Program programs[] = {
+      { "run\"dmatest\r",   "DMA sound channels" },
+      { "run\"asicrast\r", "raster interrupts"  },
+      { "run\"hscrl\r",     "hardware scroll"    },
+      { "run\"lumasic\r",   "ASIC palette"       },
+   };
+
+   for (size_t i = 0; i < sizeof(programs) / sizeof(programs[0]); ++i)
+   {
+      SCOPED_TRACE(programs[i].what);
+      CheckOneMachine("6128PLUSPARADOS", 137, kAsicDisk, programs[i].what,
+                      nullptr, 0, programs[i].command);
+   }
+}
+
+// A cartridge is media, like a disk or a tape: the state carries which bank the
+// machine is looking at, never the half-megabyte of ROM behind it.
+//
+// This runs a real Plus demo from a .cpr rather than sitting at a prompt, for
+// the same reason the ASIC cases exist -- a cartridge that is merely inserted
+// exercises nothing the base machine does not.
+TEST(MachineStateTest, RestoringAStateReproducesTheSameRunFromACartridge)
+{
+   const int kSlicesAfter = 400;
+   const char* kCart = "./res/CART/Eerie_Forest_(Logon_System_2017).cpr";
+
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      NewBootedMachine(dirImp, display, log, soundFactory, conf_manager, "GX4000");
+
+   ASSERT_EQ(0, machine->LoadCpr(kCart))
+      << "the cartridge did not load, so this case proves nothing: " << kCart;
+   machine->Reinit();
+
+   // Let the demo get going: a cartridge that has only just been inserted is as
+   // idle as an empty machine.
+   for (int i = 0; i < 600; ++i)
+      machine->RunTimeSlice();
+
+   int ram_in_use = 0;
+   const unsigned char* ram = machine->GetMem()->GetRamBuffer();
+   for (int i = 0; i < 0x10000; ++i) if (ram[i] != 0) ++ram_in_use;
+   ASSERT_GT(ram_in_use, 0) << "the cartridge never ran";
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+
+   srand(0x5AFE5EED);
+   for (int i = 0; i < kSlicesAfter; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint straight_through = Capture(machine);
+
+   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()));
+   srand(0x5AFE5EED);
+   for (int i = 0; i < kSlicesAfter; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint after_restore = Capture(machine);
+
+   delete machine;
+
+   int divergent = 0;
+   for (size_t i = 0; i < straight_through.fields.size(); ++i)
+   {
+      if (straight_through.fields[i].second == after_restore.fields[i].second) continue;
+      ++divergent;
+      fprintf(stderr, "  STILL DIVERGES: %s\n", straight_through.fields[i].first.c_str());
+   }
+   fprintf(stderr, "MACHINE STATE gx4000    cartridge  %d of %zu fields diverged\n",
+      divergent, straight_through.fields.size());
+
+   EXPECT_EQ(0, divergent) << "the state did not carry everything a cartridge run needs";
 }

--- a/UnitTests/TestMachineState.cpp
+++ b/UnitTests/TestMachineState.cpp
@@ -8,6 +8,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
+#include <io.h>
 #include <process.h>
 #define getpid _getpid
 #endif
@@ -496,6 +497,28 @@ namespace
 
 const char kStateOutFlag[] = "--machine-state-out=";
 
+// A path no other process can be using.
+//
+// A fixed name in the temp directory is shared by every test process on the
+// machine, and a name built from the process id still collides with a stale file
+// left by a crashed run that happened to have the same id. Let the OS pick,
+// atomically, and delete it when done.
+std::string CreateUniqueStatePath()
+{
+   std::string pattern = testing::TempDir() + "cpccore_state_XXXXXX";
+   std::vector<char> buffer(pattern.begin(), pattern.end());
+   buffer.push_back('\0');
+
+#ifndef _WIN32
+   const int fd = mkstemp(&buffer[0]);
+   if (fd < 0) return std::string();
+   close(fd);
+#else
+   if (_mktemp_s(&buffer[0], buffer.size()) != 0) return std::string();
+#endif
+   return std::string(&buffer[0]);
+}
+
 std::string ArgumentValue(const char* prefix)
 {
    const std::vector<std::string> argv = testing::internal::GetArgvs();
@@ -592,16 +615,9 @@ TEST(MachineStateTest, LoadsAStateWrittenByAnotherProcess)
    const std::vector<std::string> argv = testing::internal::GetArgvs();
    ASSERT_FALSE(argv.empty());
 
-   // Per-process path. A fixed name in the temp directory is shared by every
-   // test process on the machine, so two runs at once -- ctest -j, or simply two
-   // shells -- would overwrite each other's state between the child writing it
-   // and the parent reading it.
-   char unique[64];
-   snprintf(unique, sizeof(unique), "cpccore_cross_process_%ld.state", (long)getpid());
-   const std::string state_path = testing::TempDir() + unique;
+   const std::string state_path = CreateUniqueStatePath();
+   ASSERT_FALSE(state_path.empty()) << "could not create a temporary file";
    const std::string fingerprint_path = state_path + ".fingerprint";
-   remove(state_path.c_str());
-   remove(fingerprint_path.c_str());
 
    std::string command = "\"" + argv[0] + "\""
       + " --gtest_also_run_disabled_tests"

--- a/UnitTests/TestMachineStateExpansions.cpp
+++ b/UnitTests/TestMachineStateExpansions.cpp
@@ -1,0 +1,164 @@
+#include "gtest/gtest.h"
+
+#include "TestUtils.h"
+#include "MachineState.h"
+#include "Motherboard.h"
+#include "DMA.h"
+#include "PlayCity.h"
+
+#include <cstring>
+#include <vector>
+
+// The Plus DMA channels and the PlayCity expansion.
+//
+// What this proves, and what it does not: the other MachineState tests run a
+// whole machine and compare two runs, which is the strong form. Neither of
+// these components can be driven that way here -- the unit tests never plug
+// PlayCity in (the libretro wrapper does that, through sig->exp_list_), and
+// reaching the DMA channels from emulated code needs a Plus program doing sound
+// DMA. So these tests set the state directly, round trip it, and check it comes
+// back. That catches a field left out of a chunk, which is the mistake actually
+// being guarded against here; it does not prove the components then behave the
+// same, and no claim is made that it does.
+
+namespace
+{
+
+EmulatorEngine* Boot(DirectoriesImp& dirImp, CDisplay& display, Log& log,
+                     SoundFactory& soundFactory, ConfigurationManager& conf_manager,
+                     const char* section)
+{
+   EmulatorEngine* machine = new EmulatorEngine();
+   display.Init(false);
+   display.Show(false);
+   machine->SetDirectories(&dirImp);
+   machine->SetLog(&log);
+   machine->SetConfigurationManager(&conf_manager);
+   machine->Init(&display, &soundFactory);
+   machine->GetMem()->Initialisation();
+   machine->LoadConfiguration(section, "./TestConf.ini");
+   machine->Reinit();
+   machine->SetFixedSpeed(true);
+   machine->SetSpeedLimit(EmulatorEngine::E_FULL);
+   for (int i = 0; i < 100; ++i)
+      machine->RunTimeSlice();
+   return machine;
+}
+
+// Raw bytes of a component, so a field missing from a chunk shows up whether or
+// not anyone remembered to name it.
+std::vector<unsigned char> Bytes(const void* p, size_t n)
+{
+   const unsigned char* b = static_cast<const unsigned char*>(p);
+   return std::vector<unsigned char>(b, b + n);
+}
+
+size_t CountDiffering(const std::vector<unsigned char>& a, const void* p)
+{
+   const unsigned char* b = static_cast<const unsigned char*>(p);
+   size_t n = 0;
+   for (size_t i = 0; i < a.size(); ++i)
+      if (a[i] != b[i]) ++n;
+   return n;
+}
+
+}  // namespace
+
+TEST(MachineStateExpansions, CarriesTheDmaChannels)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine = Boot(dirImp, display, log, soundFactory, conf_manager, "6128PLUS");
+
+   Motherboard* board = machine->GetMotherboard();
+
+   // A channel mid-program: the .SNA's CPC+ chunk has fields for only three of
+   // these, so the rest is exactly what used to be lost.
+   for (int i = 0; i < 3; ++i)
+   {
+      DMA* d = board->GetDMA(i);
+      d->pause_counter_ = 100 + i;
+      d->repeat_counter_ = 200 + i;
+      d->repeat_addr_ = (unsigned short)(0x4000 + i);
+      d->curent_instr_ = (unsigned short)(0x1234 + i);
+      d->enable_next_ = true;
+      d->ppr_ = (unsigned char)(0x10 + i);
+      d->interrupt_on_ = true;
+      d->prescalar_ = (unsigned char)(3 + i);
+      d->prescalar_counter_ = (unsigned char)(1 + i);
+   }
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+
+   std::vector<std::vector<unsigned char> > before;
+   for (int i = 0; i < 3; ++i)
+      before.push_back(Bytes(board->GetDMA(i), sizeof(DMA)));
+
+   // Scribble over it, so a restore that does nothing cannot pass.
+   for (int i = 0; i < 3; ++i)
+   {
+      DMA* d = board->GetDMA(i);
+      d->pause_counter_ = 0; d->repeat_counter_ = 0; d->repeat_addr_ = 0;
+      d->curent_instr_ = 0; d->enable_next_ = false; d->ppr_ = 0;
+      d->interrupt_on_ = false; d->prescalar_ = 0; d->prescalar_counter_ = 0;
+   }
+   ASSERT_NE(0u, CountDiffering(before[0], board->GetDMA(0)))
+      << "the scribble did not take, so a pass would prove nothing";
+
+   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()));
+
+   size_t differing = 0;
+   for (int i = 0; i < 3; ++i)
+      differing += CountDiffering(before[i], board->GetDMA(i));
+
+   delete machine;
+   EXPECT_EQ(0u, differing) << "a DMA channel did not come back as it was saved";
+}
+
+TEST(MachineStateExpansions, CarriesPlayCity)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine = Boot(dirImp, display, log, soundFactory, conf_manager, "6128");
+
+   Motherboard* board = machine->GetMotherboard();
+   PlayCity* pc = board->GetPlayCity();
+
+   // Plug it in the way the libretro wrapper does, so the CTC and the two sound
+   // chips are actually clocked while the machine runs.
+   CSig* sig = machine->GetSig();
+   sig->nb_expansion_ = 0;
+   sig->exp_list_[sig->nb_expansion_++] = pc;
+
+   // Drive it: select a channel on each chip and give the CTC a time constant.
+   unsigned char data;
+   data = 7;    pc->Out(0xF884, data);   // register select, right chip
+   data = 0x3E; pc->Out(0xF984, data);   // mixer: tone A only
+   data = 0;    pc->Out(0xF888, data);   // register select, left chip
+   data = 0x80; pc->Out(0xF988, data);
+   data = 0xA5; pc->Out(0xF880, data);   // CTC channel 0 control
+   data = 0x40; pc->Out(0xF880, data);   // ... and its time constant
+
+   for (int i = 0; i < 50; ++i)
+      machine->RunTimeSlice();
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+
+   // After the save, not before: saving steps the machine to the next Z80
+   // instruction boundary, and PlayCity is clocked while it does.
+   const std::vector<unsigned char> before = Bytes(pc, sizeof(PlayCity));
+
+   for (int i = 0; i < 50; ++i)
+      machine->RunTimeSlice();
+   ASSERT_NE(0u, CountDiffering(before, pc))
+      << "PlayCity did not change while running, so this test would pass either way";
+
+   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()));
+
+   const size_t differing = CountDiffering(before, pc);
+   delete machine;
+
+   EXPECT_EQ(0u, differing) << "PlayCity did not come back as it was saved";
+}

--- a/UnitTests/TestMachineStateRam.cpp
+++ b/UnitTests/TestMachineStateRam.cpp
@@ -235,3 +235,63 @@ TEST(MachineStateRam, RefusesAMalformedExpansionChunk)
 
    delete machine;
 }
+
+// A refused state must leave the machine untouched, not part restored.
+//
+// The chunks are applied one after another, so a refusal partway used to leave
+// the .SNA and every earlier chunk already in place: the frontend reports a
+// failed load and the user carries on with a machine that is neither where it
+// was nor where the state wanted it.
+TEST(MachineStateRam, ARefusedStateLeavesTheMachineAlone)
+{
+   std::vector<unsigned char> foreign;
+   {
+      DirectoriesImp dirImp; CDisplay display; Log log;
+      SoundFactory soundFactory; ConfigurationManager conf_manager;
+      EmulatorEngine* other =
+         BootWithConfig(dirImp, display, log, soundFactory, conf_manager, k576K.cfg);
+      ASSERT_EQ(8, AvailablePages(other));
+      PoisonPages(other, 0x70);
+      ASSERT_TRUE(MachineState::Save(other, foreign));
+      delete other;
+   }
+
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      BootWithConfig(dirImp, display, log, soundFactory, conf_manager, k128K.cfg);
+   ASSERT_EQ(1, AvailablePages(machine));
+
+   machine->GetMem()->ConnectBank(0, 0, 0);
+   machine->GetMem()->Set(kProbe, 0x3C);
+   PoisonPages(machine, 0xE0);
+
+   // Fingerprint the machine widely enough that a partial restore shows up.
+   const std::vector<int> pages_before = ReadPages(machine);
+   machine->GetMem()->ConnectBank(0, 0, 0);
+   const int base_before = machine->GetMem()->Get(kProbe);
+   const unsigned short pc_before = machine->GetProc()->pc_;
+   const unsigned short sp_before = machine->GetProc()->sp_;
+   const unsigned char hcc_before = machine->GetCRTC()->hcc_;
+   const unsigned char vcc_before = machine->GetCRTC()->vcc_;
+
+   ASSERT_FALSE(MachineState::Load(machine, &foreign[0], foreign.size()))
+      << "a 576K state was accepted by a 128K machine";
+
+   const std::vector<int> pages_after = ReadPages(machine);
+   machine->GetMem()->ConnectBank(0, 0, 0);
+   const int base_after = machine->GetMem()->Get(kProbe);
+   const unsigned short pc_after = machine->GetProc()->pc_;
+   const unsigned short sp_after = machine->GetProc()->sp_;
+   const unsigned char hcc_after = machine->GetCRTC()->hcc_;
+   const unsigned char vcc_after = machine->GetCRTC()->vcc_;
+
+   delete machine;
+
+   EXPECT_EQ(pages_before, pages_after)   << "RAM was modified by a refused load";
+   EXPECT_EQ(base_before, base_after)     << "the base bank was modified by a refused load";
+   EXPECT_EQ(pc_before, pc_after)         << "the CPU was moved by a refused load";
+   EXPECT_EQ(sp_before, sp_after)         << "the CPU was moved by a refused load";
+   EXPECT_EQ(hcc_before, hcc_after)       << "the CRTC was moved by a refused load";
+   EXPECT_EQ(vcc_before, vcc_after)       << "the CRTC was moved by a refused load";
+}

--- a/UnitTests/TestMachineStateRam.cpp
+++ b/UnitTests/TestMachineStateRam.cpp
@@ -1,0 +1,237 @@
+#include "gtest/gtest.h"
+
+#include "TestUtils.h"
+#include "MachineState.h"
+#include "Motherboard.h"
+
+#include <string>
+#include <vector>
+
+// Expansion RAM: 64 KB, 128 KB and 576 KB machines, and the ways a state can be
+// applied to the wrong one.
+//
+// The .SNA carries the base bank and at most one expansion page, so everything
+// above 128 KB used to vanish. These use the configurations Sugarbox ships --
+// CPC464FR for 64 KB, CPC6128FR for 128 KB, CPC6128SymbOs for 576 KB -- rather
+// than fixtures invented for the test, so what is covered is what a user runs.
+//
+// Every page is written through the bus, with the machine paging it in the way
+// a program would, and with a different pattern per page. A test that only
+// checked "some data came back" would pass while pages were swapped.
+
+namespace
+{
+
+EmulatorEngine* BootWithConfig(DirectoriesImp& dirImp, CDisplay& display, Log& log,
+                               SoundFactory& soundFactory, ConfigurationManager& conf_manager,
+                               const char* cfg)
+{
+   EmulatorEngine* machine = new EmulatorEngine();
+   display.Init(false);
+   display.Show(false);
+   machine->SetDirectories(&dirImp);
+   machine->SetLog(&log);
+   machine->SetConfigurationManager(&conf_manager);
+   machine->Init(&display, &soundFactory);
+   machine->GetMem()->Initialisation();
+   machine->LoadConfiguration(cfg);
+   machine->Reinit();
+   machine->SetFixedSpeed(true);
+   machine->SetSpeedLimit(EmulatorEngine::E_FULL);
+   for (int i = 0; i < 20; ++i)
+      machine->RunTimeSlice();
+   return machine;
+}
+
+int AvailablePages(EmulatorEngine* machine)
+{
+   const bool* available = machine->GetMem()->GetAvailableRam();
+   int n = 0;
+   for (int i = 0; i < 8; ++i) if (available[i]) ++n;
+   return n;
+}
+
+// Page `page` fully mapped over 0x0000-0xFFFF is RAM configuration 2; the byte
+// at 0x4000 then lands in that page's second bank, away from the screen and the
+// firmware's own variables.
+const unsigned short kProbe = 0x4000;
+
+void PoisonPages(EmulatorEngine* machine, unsigned char seed)
+{
+   const bool* available = machine->GetMem()->GetAvailableRam();
+   for (int page = 0; page < 8; ++page)
+   {
+      if (!available[page]) continue;
+      machine->GetMem()->ConnectBank((unsigned char)page, 0, 2);
+      machine->GetMem()->Set(kProbe, (unsigned char)(seed + page));
+   }
+   machine->GetMem()->ConnectBank(0, 0, 0);
+}
+
+std::vector<int> ReadPages(EmulatorEngine* machine)
+{
+   const bool* available = machine->GetMem()->GetAvailableRam();
+   std::vector<int> out;
+   for (int page = 0; page < 8; ++page)
+   {
+      if (!available[page]) { out.push_back(-1); continue; }
+      machine->GetMem()->ConnectBank((unsigned char)page, 0, 2);
+      out.push_back(machine->GetMem()->Get(kProbe));
+   }
+   machine->GetMem()->ConnectBank(0, 0, 0);
+   return out;
+}
+
+struct Machine
+{
+   const char* cfg;
+   const char* label;
+   int expected_pages;
+};
+
+const Machine k64K  = { "CONF/CPC464FR.cfg",     "64K",  0 };
+const Machine k128K = { "CONF/CPC6128FR.cfg",    "128K", 1 };
+const Machine k576K = { "CONF/CPC6128SymbOs.cfg","576K", 8 };
+
+}  // namespace
+
+TEST(MachineStateRam, CarriesEveryExpansionPage)
+{
+   const Machine machines[] = { k64K, k128K, k576K };
+
+   for (size_t m = 0; m < sizeof(machines) / sizeof(machines[0]); ++m)
+   {
+      SCOPED_TRACE(machines[m].label);
+
+      DirectoriesImp dirImp; CDisplay display; Log log;
+      SoundFactory soundFactory; ConfigurationManager conf_manager;
+      EmulatorEngine* machine =
+         BootWithConfig(dirImp, display, log, soundFactory, conf_manager, machines[m].cfg);
+
+      ASSERT_EQ(machines[m].expected_pages, AvailablePages(machine))
+         << machines[m].cfg << " did not give the memory this case is about";
+
+      // The base bank is written the same way whether or not the machine has
+      // expansion pages, so the 64 KB case still proves a round trip.
+      machine->GetMem()->ConnectBank(0, 0, 0);
+      machine->GetMem()->Set(kProbe, 0x5A);
+
+      PoisonPages(machine, 0xA0);
+      const std::vector<int> written = ReadPages(machine);
+
+      std::vector<unsigned char> state;
+      ASSERT_TRUE(MachineState::Save(machine, state));
+
+      // Overwrite everything, so a restore that does nothing cannot pass.
+      machine->GetMem()->ConnectBank(0, 0, 0);
+      machine->GetMem()->Set(kProbe, 0xC3);
+      PoisonPages(machine, 0x10);
+      if (machines[m].expected_pages > 0)
+         ASSERT_NE(written, ReadPages(machine))
+            << "the overwrite did not take, so this case would prove nothing";
+      machine->GetMem()->ConnectBank(0, 0, 0);
+      ASSERT_EQ(0xC3, machine->GetMem()->Get(kProbe))
+         << "the base bank overwrite did not take";
+
+      ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()));
+      const std::vector<int> restored = ReadPages(machine);
+      machine->GetMem()->ConnectBank(0, 0, 0);
+      const int base_restored = machine->GetMem()->Get(kProbe);
+
+      const size_t size = state.size();
+      delete machine;
+
+      EXPECT_EQ(written, restored) << "an expansion page did not come back";
+      EXPECT_EQ(0x5A, base_restored) << "the base bank did not come back";
+      fprintf(stderr, "  RAM %-5s %d pages, state %zu bytes (%.1f KB)\n",
+         machines[m].label, machines[m].expected_pages, size, size / 1024.0);
+   }
+}
+
+// The nasty cases: a state is only meaningful against a machine with the same
+// memory. Applying one to the wrong machine would drop pages silently in one
+// direction and leave stale ones behind in the other.
+TEST(MachineStateRam, RefusesAStateFromAMachineWithDifferentMemory)
+{
+   struct Pair { const Machine* saver; const Machine* loader; };
+   const Pair pairs[] = {
+      { &k576K, &k128K }, { &k128K, &k576K },
+      { &k576K, &k64K  }, { &k64K,  &k576K },
+      { &k128K, &k64K  }, { &k64K,  &k128K },
+   };
+
+   for (size_t i = 0; i < sizeof(pairs) / sizeof(pairs[0]); ++i)
+   {
+      SCOPED_TRACE(std::string(pairs[i].saver->label) + " -> " + pairs[i].loader->label);
+
+      std::vector<unsigned char> state;
+      {
+         DirectoriesImp dirImp; CDisplay display; Log log;
+         SoundFactory soundFactory; ConfigurationManager conf_manager;
+         EmulatorEngine* saver =
+            BootWithConfig(dirImp, display, log, soundFactory, conf_manager, pairs[i].saver->cfg);
+         ASSERT_EQ(pairs[i].saver->expected_pages, AvailablePages(saver));
+         ASSERT_TRUE(MachineState::Save(saver, state));
+         delete saver;
+      }
+
+      DirectoriesImp dirImp; CDisplay display; Log log;
+      SoundFactory soundFactory; ConfigurationManager conf_manager;
+      EmulatorEngine* loader =
+         BootWithConfig(dirImp, display, log, soundFactory, conf_manager, pairs[i].loader->cfg);
+      ASSERT_EQ(pairs[i].loader->expected_pages, AvailablePages(loader));
+
+      const bool loaded = MachineState::Load(loader, &state[0], state.size());
+      delete loader;
+
+      EXPECT_FALSE(loaded)
+         << pairs[i].saver->label << " state was applied to a " << pairs[i].loader->label
+         << " machine instead of being refused";
+   }
+}
+
+// A truncated or padded expansion chunk must be refused rather than read past
+// its end or leave pages half written.
+TEST(MachineStateRam, RefusesAMalformedExpansionChunk)
+{
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine =
+      BootWithConfig(dirImp, display, log, soundFactory, conf_manager, k576K.cfg);
+   ASSERT_EQ(8, AvailablePages(machine));
+
+   std::vector<unsigned char> state;
+   ASSERT_TRUE(MachineState::Save(machine, state));
+   ASSERT_TRUE(MachineState::Load(machine, &state[0], state.size()))
+      << "the unmodified state must load, or the cases below prove nothing";
+
+   // Find the expansion chunk and corrupt its declared length.
+   const unsigned int sna_len = state[8] | (state[9] << 8)
+                              | (state[10] << 16) | ((unsigned int)state[11] << 24);
+   size_t at = 12 + sna_len;
+   size_t xram_at = 0;
+   while (at + 8 <= state.size())
+   {
+      const unsigned int id = state[at] | (state[at+1] << 8)
+                            | (state[at+2] << 16) | ((unsigned int)state[at+3] << 24);
+      const unsigned int len = state[at+4] | (state[at+5] << 8)
+                             | (state[at+6] << 16) | ((unsigned int)state[at+7] << 24);
+      if (id == 0x5852414D) { xram_at = at; break; }
+      at += 8 + len;
+   }
+   ASSERT_NE(0u, xram_at) << "no expansion chunk in a 576K state";
+
+   std::vector<unsigned char> shortened = state;
+   shortened[xram_at + 4] -= 1;                 // one byte less than written
+   EXPECT_FALSE(MachineState::Load(machine, &shortened[0], shortened.size()));
+
+   std::vector<unsigned char> wrong_mask = state;
+   wrong_mask[xram_at + 8] = 0x03;              // claim two pages, carry eight
+   EXPECT_FALSE(MachineState::Load(machine, &wrong_mask[0], wrong_mask.size()));
+
+   std::vector<unsigned char> cut = state;
+   cut.resize(xram_at + 12);                    // chunk header, no payload
+   EXPECT_FALSE(MachineState::Load(machine, &cut[0], cut.size()));
+
+   delete machine;
+}

--- a/UnitTests/TestMachineStateSize.cpp
+++ b/UnitTests/TestMachineStateSize.cpp
@@ -4,6 +4,7 @@
 #include "MachineState.h"
 
 #include <cstdio>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -46,13 +47,23 @@ unsigned int U32At(const std::vector<unsigned char>& b, size_t at)
 
 TEST(MachineStateSize, ReportsWhatAStateCosts)
 {
-   const char* sections[] = { "464", "6128", "6128PLUS" };
+   const char* sections[] = { "464", "6128", "6128PLUS", "GX4000" };
 
    for (size_t s = 0; s < sizeof(sections) / sizeof(sections[0]); ++s)
    {
       DirectoriesImp dirImp; CDisplay display; Log log;
       SoundFactory soundFactory; ConfigurationManager conf_manager;
       EmulatorEngine* machine = Boot(dirImp, display, log, soundFactory, conf_manager, sections[s]);
+
+      // On the cartridge machine, insert a 512 KB cartridge: the state must not
+      // grow by anything like that, because the ROM is media, not state.
+      if (strcmp(sections[s], "GX4000") == 0)
+      {
+         ASSERT_EQ(0, machine->LoadCpr("./res/CART/Eerie_Forest_(Logon_System_2017).cpr"));
+         machine->Reinit();
+         for (int i = 0; i < 300; ++i)
+            machine->RunTimeSlice();
+      }
 
       std::vector<unsigned char> state;
       ASSERT_TRUE(MachineState::Save(machine, state));
@@ -91,5 +102,11 @@ TEST(MachineStateSize, ReportsWhatAStateCosts)
 
       EXPECT_EQ(state.size(), 12 + sna_len + chunk_total)
          << "the chunk walk did not account for the whole state";
+
+      // The cartridge machine has half a megabyte of ROM plugged into it. If it
+      // ever shows up here, someone has started serialising media.
+      if (strcmp(sections[s], "GX4000") == 0)
+         EXPECT_LT(state.size(), 160u * 1024u)
+            << "the state grew with the cartridge, so the ROM is being carried";
    }
 }

--- a/UnitTests/TestMachineStateSize.cpp
+++ b/UnitTests/TestMachineStateSize.cpp
@@ -1,0 +1,95 @@
+#include "gtest/gtest.h"
+
+#include "TestUtils.h"
+#include "MachineState.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+// What a state actually costs.
+//
+// A libretro frontend allocates one buffer from retro_serialize_size() and
+// reuses it for every save, and rewind keeps dozens of them, so the number
+// matters as much as the contents.
+
+namespace
+{
+
+EmulatorEngine* Boot(DirectoriesImp& dirImp, CDisplay& display, Log& log,
+                     SoundFactory& soundFactory, ConfigurationManager& conf_manager,
+                     const char* section)
+{
+   EmulatorEngine* machine = new EmulatorEngine();
+   display.Init(false);
+   display.Show(false);
+   machine->SetDirectories(&dirImp);
+   machine->SetLog(&log);
+   machine->SetConfigurationManager(&conf_manager);
+   machine->Init(&display, &soundFactory);
+   machine->GetMem()->Initialisation();
+   machine->LoadConfiguration(section, "./TestConf.ini");
+   machine->Reinit();
+   machine->SetFixedSpeed(true);
+   machine->SetSpeedLimit(EmulatorEngine::E_FULL);
+   for (int i = 0; i < 200; ++i)
+      machine->RunTimeSlice();
+   return machine;
+}
+
+unsigned int U32At(const std::vector<unsigned char>& b, size_t at)
+{
+   return b[at] | (b[at+1] << 8) | (b[at+2] << 16) | ((unsigned int)b[at+3] << 24);
+}
+
+}  // namespace
+
+TEST(MachineStateSize, ReportsWhatAStateCosts)
+{
+   const char* sections[] = { "464", "6128", "6128PLUS" };
+
+   for (size_t s = 0; s < sizeof(sections) / sizeof(sections[0]); ++s)
+   {
+      DirectoriesImp dirImp; CDisplay display; Log log;
+      SoundFactory soundFactory; ConfigurationManager conf_manager;
+      EmulatorEngine* machine = Boot(dirImp, display, log, soundFactory, conf_manager, sections[s]);
+
+      std::vector<unsigned char> state;
+      ASSERT_TRUE(MachineState::Save(machine, state));
+
+      std::vector<unsigned char> sna;
+      ASSERT_TRUE(machine->SaveSnapshotNow(sna));
+
+      delete machine;
+
+      const unsigned int sna_len = U32At(state, 8);
+      fprintf(stderr, "\nSTATE SIZE %-9s total %8zu bytes (%6.1f KB)\n",
+         sections[s], state.size(), state.size() / 1024.0);
+      fprintf(stderr, "  .SNA image        %8u bytes (%6.1f KB)  %5.1f%%\n",
+         sna_len, sna_len / 1024.0, 100.0 * sna_len / state.size());
+      fprintf(stderr, "  header              %8d bytes\n", 12);
+
+      // Walk the chunks that follow the .SNA.
+      size_t at = 12 + sna_len;
+      size_t chunk_total = 0;
+      while (at + 8 <= state.size())
+      {
+         const unsigned int id = U32At(state, at);
+         const unsigned int len = U32At(state, at + 4);
+         char name[5] = {0};
+         name[0] = (char)((id >> 24) & 0xFF); name[1] = (char)((id >> 16) & 0xFF);
+         name[2] = (char)((id >> 8) & 0xFF);  name[3] = (char)(id & 0xFF);
+         fprintf(stderr, "  chunk %-4s          %8u bytes\n", name, len + 8);
+         chunk_total += len + 8;
+         at += 8 + len;
+      }
+      fprintf(stderr, "  chunks total      %8zu bytes  %5.1f%%\n",
+         chunk_total, 100.0 * chunk_total / state.size());
+      fprintf(stderr, "  vs a plain .SNA   %8zu bytes  (+%.1f%%)\n",
+         state.size() - sna.size(),
+         100.0 * (state.size() - sna.size()) / sna.size());
+
+      EXPECT_EQ(state.size(), 12 + sna_len + chunk_total)
+         << "the chunk walk did not account for the whole state";
+   }
+}

--- a/UnitTests/TestStateDeterminism.cpp
+++ b/UnitTests/TestStateDeterminism.cpp
@@ -1,0 +1,191 @@
+#include "gtest/gtest.h"
+
+#include "TestUtils.h"
+
+#include <string>
+#include <vector>
+
+// Does saving a state and restoring it put the machine back where it was?
+//
+// The check is differential rather than absolute: run on from a save point,
+// fingerprint the machine, restore, run on the same distance again, and
+// fingerprint again. Anything the snapshot failed to carry shows up as a
+// divergence between the two, because the restored run started from an
+// incomplete machine.
+//
+// Fingerprints are taken per component so a failure names the component that
+// was not carried, instead of reporting one opaque hash mismatch. That is the
+// point of this harness: it is meant to tell us what is still missing from the
+// serialiser as components get added, not just that something is.
+
+namespace
+{
+
+struct Fingerprint
+{
+   std::vector<std::pair<std::string, unsigned long long> > fields;
+
+   void Add(const char* name, unsigned long long value)
+   {
+      fields.push_back(std::make_pair(std::string(name), value));
+   }
+
+   void AddBlock(const char* name, const unsigned char* data, size_t size)
+   {
+      // FNV-1a, only needs to be stable and to change when the block does.
+      unsigned long long h = 14695981039346656037ULL;
+      for (size_t i = 0; i < size; ++i)
+      {
+         h ^= data[i];
+         h *= 1099511628211ULL;
+      }
+      Add(name, h);
+   }
+};
+
+Fingerprint Capture(EmulatorEngine* machine)
+{
+   Fingerprint f;
+
+   f.AddBlock("ram", machine->GetMem()->GetRamBuffer(), 0x10000);
+
+   Z80* z80 = machine->GetProc();
+   f.Add("z80.pc", z80->pc_);
+   f.Add("z80.sp", z80->sp_);
+   f.Add("z80.iff1", z80->iff1_ ? 1 : 0);
+   f.Add("z80.iff2", z80->iff2_ ? 1 : 0);
+   f.Add("z80.opcode", z80->current_opcode_);
+   f.Add("z80.machine_cycle", z80->machine_cycle_);
+   f.Add("z80.t", z80->t_);
+
+   CRTC* crtc = machine->GetCRTC();
+   f.Add("crtc.hcc", crtc->hcc_);
+   f.Add("crtc.vcc", crtc->vcc_);
+   f.Add("crtc.vlc", crtc->vlc_);
+   f.AddBlock("crtc.registers", crtc->registers_list_, sizeof(crtc->registers_list_));
+
+   CTape* tape = machine->GetTape();
+   f.Add("tape.position", tape->GetTapePosition());
+   f.Add("tape.inversions", tape->GetNbInversions());
+   f.Add("tape.recording", tape->IsRecordOn() ? 1 : 0);
+
+   f.Add("fdc.track0", machine->GetFDC()->GetCurrentTrack(0));
+   f.Add("fdc.motor", machine->GetFDC()->IsMotorOn() ? 1 : 0);
+
+   return f;
+}
+
+EmulatorEngine* NewBootedMachine(DirectoriesImp& dirImp, CDisplay& display, Log& log,
+                                 SoundFactory& soundFactory, ConfigurationManager& conf_manager)
+{
+   EmulatorEngine* machine = new EmulatorEngine();
+
+   display.Init(false);
+   display.Show(false);
+
+   machine->SetDirectories(&dirImp);
+   machine->SetLog(&log);
+   machine->SetConfigurationManager(&conf_manager);
+   machine->Init(&display, &soundFactory);
+   machine->GetMem()->Initialisation();
+   machine->LoadConfiguration("./TestConf.ini", "./TestConf_0.ini");
+   machine->Reinit();
+   machine->SetFixedSpeed(true);
+   machine->SetSpeedLimit(EmulatorEngine::E_FULL);
+
+   return machine;
+}
+
+}  // namespace
+
+// Two separate questions, asserted separately, because they have very different
+// answers today.
+//
+// 1. RESTORE FIDELITY -- does the machine come back exactly as it was saved?
+//    Yes, for every field below. This is a hard assertion: any field that stops
+//    matching here is a real regression in the .SNA path.
+//
+// 2. RUN-ON DETERMINISM -- does the restored machine then run the same way?
+//    No, and not for any field. Motherboard::component_elapsed_time_[] and
+//    IComponent::this_tick_time_ hold each component's cycle debt across time
+//    slices and are not in the container, so a restored machine resumes with
+//    every component's scheduling phase reset. The CPU and CRTC drift apart
+//    within a slice and the program takes a different path from there.
+//    Asserting field-by-field equality here would just be asserting that a
+//    known-missing feature is present, so this is a ratchet instead: the number
+//    of divergent fields may fall as the serialiser grows, never rise.
+TEST(StateDeterminism, RestoringAStateReproducesTheSameRun)
+{
+   // Every field diverges once the machine runs on. Lower this as the
+   // serialiser carries more; it must never need raising.
+   const int kDivergentFieldsBaseline = 11;
+
+   const int kSlicesBeforeSave = 20;
+   // Long enough to be a meaningful control. At ten slices a .SNA round trip
+   // happens to stay in step, which made this look far better than it is.
+   const int kSlicesAfterSave = 400;
+
+   DirectoriesImp dirImp; CDisplay display; Log log;
+   SoundFactory soundFactory; ConfigurationManager conf_manager;
+   EmulatorEngine* machine = NewBootedMachine(dirImp, display, log, soundFactory, conf_manager);
+
+   for (int i = 0; i < kSlicesBeforeSave; ++i)
+      machine->RunTimeSlice();
+
+   // A machine with no firmware paged in never executes, and then every
+   // fingerprint below matches for the wrong reason. Refuse to report on one.
+   int ram_in_use = 0;
+   const unsigned char* ram = machine->GetMem()->GetRamBuffer();
+   for (int i = 0; i < 0x10000; ++i) if (ram[i] != 0) ++ram_in_use;
+   ASSERT_GT(ram_in_use, 0)
+      << "the machine never executed an instruction -- no ROMs found. This test "
+         "needs CONF/, ROM/ and res/ from UnitTests/ and Keyboards/ from "
+         "CPCCoreEmu/ reachable from the working directory.";
+
+   std::vector<unsigned char> saved;
+   ASSERT_TRUE(machine->SaveSnapshotNow(saved));
+   ASSERT_FALSE(saved.empty());
+   const Fingerprint at_save = Capture(machine);
+
+   for (int i = 0; i < kSlicesAfterSave; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint straight_through = Capture(machine);
+
+   ASSERT_TRUE(machine->LoadSnapshotNow(&saved[0], saved.size()));
+   const Fingerprint at_restore = Capture(machine);
+
+   for (int i = 0; i < kSlicesAfterSave; ++i)
+      machine->RunTimeSlice();
+   const Fingerprint after_restore = Capture(machine);
+
+   delete machine;
+
+   ASSERT_EQ(at_save.fields.size(), at_restore.fields.size());
+   ASSERT_EQ(straight_through.fields.size(), after_restore.fields.size());
+
+   // 1. Restore fidelity.
+   for (size_t i = 0; i < at_save.fields.size(); ++i)
+   {
+      EXPECT_EQ(at_save.fields[i].second, at_restore.fields[i].second)
+         << at_save.fields[i].first << " did not come back from the snapshot";
+   }
+
+   // 2. Run-on determinism.
+   int divergent = 0;
+   for (size_t i = 0; i < straight_through.fields.size(); ++i)
+   {
+      if (straight_through.fields[i].second == after_restore.fields[i].second)
+         continue;
+      ++divergent;
+      fprintf(stderr, "  DIVERGES AFTER RUNNING ON: %s\n",
+         straight_through.fields[i].first.c_str());
+   }
+
+   fprintf(stderr, "DETERMINISM: %d of %zu fields restored exactly, %d diverged after "
+      "running on (baseline %d)\n",
+      static_cast<int>(at_save.fields.size()), at_save.fields.size(),
+      divergent, kDivergentFieldsBaseline);
+
+   EXPECT_LE(divergent, kDivergentFieldsBaseline)
+      << "more fields diverge than before -- the state path regressed";
+}


### PR DESCRIPTION
Adds `MachineState`, a save state for the whole engine, alongside the `.SNA`
rather than replacing it.

A `.SNA` describes the machine an Amstrad user could see. No version of it has a
field for the scheduler's per-component cycle debt, for where the CPU sits inside
an instruction, for a drive head or tape position, for the Plus DMA channels or
PlayCity, or for expansion RAM beyond the first page. A machine restored from one
drifts away from the run it came from within a few time slices.

`MachineState` keeps the `.SNA` for what that container expresses and adds chunks
for the rest. Layout: magic, version, the `.SNA` image, then
`[id][length][payload]` chunks. Unknown chunks are skipped. No file I/O; the
caller owns the buffer.

### Chunks

Thirteen: scheduler, Z80 execution state, gate array, CRTC (all 32 registers, not
the 18 the `.SNA` holds), PSG, PPI tape input level, FDC, drive positions, tape
position, DMA channels, PlayCity, expansion RAM, cartridge identity. 1267 bytes for
a machine with no cartridge, 1283 with one.

Expansion RAM is the one that changes what fits: the `.SNA` carries the base bank
and at most one page, so everything above 128 KB used to vanish.

### Deliberately not written

Host addresses. The Z80's dispatch pointer, the FDC's scan comparator and the
drive image pointers mean nothing in another process. The CPU is restored with
`PrepareForFetch(pc_)` instead, which is valid because a state is only ever taken
on an instruction boundary.

Media. Disk images, tape flux and cartridge ROM stay out. The drive and tape
chunks carry position plus the geometry it was recorded against, and the
cartridge chunk a CRC32 of the .cpr, so a state loaded against a different
medium is refused rather than applied.

### Size

| machine | state | `.SNA` part | chunks |
|---|---|---|---|
| 464 | 65.5 KB | 64.2 KB | 1267 B |
| 6128 | 129.5 KB | 128.2 KB | 1267 B |
| 6128 Plus + cartridge | 131.8 KB | 130.5 KB | 1283 B |
| GX4000 + 512 KB cartridge | 131.8 KB | 130.5 KB | 1283 B |

A machine with more expansion RAM grows by that RAM and nothing else.

### Tests

Save, run on, restore, run the same distance, compare 23 fields against the run
that never restored. 400 time slices per case, no divergent field tolerated.

- 9 idle: 6128, 464, 6128 Plus, three save points each
- 10 with a drive turning: DSK, EDSK, IPF, HFE and SCP, two save points each
- 2 with a tape running
- 4 running Plus software off `res/plus/asic.dsk`: DMA sound, raster interrupts,
  hardware scroll, ASIC palette
- 1 running a Plus demo from a `.cpr`
- 2 for the DMA channels and PlayCity on their own
- 4 for expansion RAM: 64 KB, 128 KB and 576 KB, using the configurations
  Sugarbox ships rather than fixtures invented for the test. Every page is
  written through the bus with its own pattern, so a test cannot pass while
  pages are swapped.
- 1 loading into a freshly built machine, 1 loading a state written by a second
  process
- 4 rejections: wrong disk, wrong emptiness, wrong cartridge, not a state

A component that sits idle during a test reads as perfectly carried whether it is
or not, which is why the Plus, tape and drive cases run real software instead of
sitting at a BASIC prompt.

`TestStateDeterminism` asks the same of a plain `.SNA` and stays as the control.
Its run length goes from 10 slices to 400; at 10 a `.SNA` round trip happens to
stay in step.

Endianness is checked rather than asserted: the same probe built for x86-64 and
for s390x, run under qemu, produces states of the same length whose chunks are
identical byte for byte.

Suite: 266 tests, green on Ubuntu and Windows CI.

### Limits

Disk writes are not in the state: the head position is restored, data written to
the image is not rolled back.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnVjbxoLEetx7Kgu68pUwy
